### PR TITLE
Add Subject and PaymentStatus model classes with tests

### DIFF
--- a/src/main/java/seedu/address/model/person/PaymentStatus.java
+++ b/src/main/java/seedu/address/model/person/PaymentStatus.java
@@ -1,0 +1,64 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a student's payment status.
+ * Guarantees: immutable; is valid as declared in {@link #isValidPaymentStatus(String)}
+ */
+public class PaymentStatus {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Payment status should be one of: Paid, Due, Overdue (case-insensitive)";
+
+    public final String value;
+
+    /**
+     * Constructs a {@code PaymentStatus}.
+     *
+     * @param status A valid payment status.
+     */
+    public PaymentStatus(String status) {
+        requireNonNull(status);
+        checkArgument(isValidPaymentStatus(status), MESSAGE_CONSTRAINTS);
+        value = capitalise(status);
+    }
+
+    /**
+     * Returns true if a given string is a valid payment status.
+     */
+    public static boolean isValidPaymentStatus(String test) {
+        String lower = test.trim().toLowerCase();
+        return lower.equals("paid") || lower.equals("due") || lower.equals("overdue");
+    }
+
+    private static String capitalise(String status) {
+        String lower = status.trim().toLowerCase();
+        return lower.substring(0, 1).toUpperCase() + lower.substring(1);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PaymentStatus)) {
+            return false;
+        }
+
+        PaymentStatus otherStatus = (PaymentStatus) other;
+        return value.equals(otherStatus.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Subject.java
+++ b/src/main/java/seedu/address/model/person/Subject.java
@@ -1,0 +1,60 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Subject that a student is taking.
+ * Guarantees: immutable; is valid as declared in {@link #isValidSubject(String)}
+ */
+public class Subject {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Subjects should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String subjectName;
+
+    /**
+     * Constructs a {@code Subject}.
+     *
+     * @param subject A valid subject name.
+     */
+    public Subject(String subject) {
+        requireNonNull(subject);
+        checkArgument(isValidSubject(subject), MESSAGE_CONSTRAINTS);
+        subjectName = subject;
+    }
+
+    /**
+     * Returns true if a given string is a valid subject name.
+     */
+    public static boolean isValidSubject(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return subjectName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Subject)) {
+            return false;
+        }
+
+        Subject otherSubject = (Subject) other;
+        return subjectName.equals(otherSubject.subjectName);
+    }
+
+    @Override
+    public int hashCode() {
+        return subjectName.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/model/person/PaymentStatusTest.java
+++ b/src/test/java/seedu/address/model/person/PaymentStatusTest.java
@@ -1,0 +1,72 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class PaymentStatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new PaymentStatus(null));
+    }
+
+    @Test
+    public void constructor_invalidStatus_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new PaymentStatus(""));
+        assertThrows(IllegalArgumentException.class, () -> new PaymentStatus("Unknown"));
+        assertThrows(IllegalArgumentException.class, () -> new PaymentStatus("pending"));
+    }
+
+    @Test
+    public void constructor_validStatus_capitalised() {
+        assertEquals("Paid", new PaymentStatus("paid").value);
+        assertEquals("Due", new PaymentStatus("DUE").value);
+        assertEquals("Overdue", new PaymentStatus("overdue").value);
+        assertEquals("Overdue", new PaymentStatus("OVERDUE").value);
+    }
+
+    @Test
+    public void isValidPaymentStatus() {
+        assertFalse(PaymentStatus.isValidPaymentStatus(""));
+        assertFalse(PaymentStatus.isValidPaymentStatus("Unknown"));
+        assertFalse(PaymentStatus.isValidPaymentStatus("pending"));
+        assertFalse(PaymentStatus.isValidPaymentStatus("123"));
+
+        assertTrue(PaymentStatus.isValidPaymentStatus("Paid"));
+        assertTrue(PaymentStatus.isValidPaymentStatus("paid"));
+        assertTrue(PaymentStatus.isValidPaymentStatus("PAID"));
+        assertTrue(PaymentStatus.isValidPaymentStatus("Due"));
+        assertTrue(PaymentStatus.isValidPaymentStatus("due"));
+        assertTrue(PaymentStatus.isValidPaymentStatus("Overdue"));
+        assertTrue(PaymentStatus.isValidPaymentStatus("overdue"));
+    }
+
+    @Test
+    public void toStringMethod() {
+        PaymentStatus status = new PaymentStatus("Paid");
+        assertEquals("Paid", status.toString());
+    }
+
+    @Test
+    public void equals() {
+        PaymentStatus status = new PaymentStatus("Paid");
+
+        assertTrue(status.equals(status));
+        assertTrue(status.equals(new PaymentStatus("Paid")));
+        assertTrue(status.equals(new PaymentStatus("paid")));
+
+        assertFalse(status.equals(null));
+        assertFalse(status.equals("Paid"));
+        assertFalse(status.equals(new PaymentStatus("Due")));
+    }
+
+    @Test
+    public void hashCodeMethod() {
+        PaymentStatus status = new PaymentStatus("Paid");
+        assertEquals(status.hashCode(), new PaymentStatus("paid").hashCode());
+    }
+}

--- a/src/test/java/seedu/address/model/person/SubjectTest.java
+++ b/src/test/java/seedu/address/model/person/SubjectTest.java
@@ -1,0 +1,60 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SubjectTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Subject(null));
+    }
+
+    @Test
+    public void constructor_invalidSubject_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new Subject(""));
+        assertThrows(IllegalArgumentException.class, () -> new Subject(" "));
+        assertThrows(IllegalArgumentException.class, () -> new Subject("Math@"));
+    }
+
+    @Test
+    public void isValidSubject() {
+        assertFalse(Subject.isValidSubject(""));
+        assertFalse(Subject.isValidSubject(" "));
+        assertFalse(Subject.isValidSubject("Math!"));
+        assertFalse(Subject.isValidSubject("@Science"));
+
+        assertTrue(Subject.isValidSubject("Mathematics"));
+        assertTrue(Subject.isValidSubject("English Literature"));
+        assertTrue(Subject.isValidSubject("H2 Physics"));
+        assertTrue(Subject.isValidSubject("3"));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Subject subject = new Subject("Mathematics");
+        assertEquals("Mathematics", subject.toString());
+    }
+
+    @Test
+    public void equals() {
+        Subject subject = new Subject("Mathematics");
+
+        assertTrue(subject.equals(subject));
+        assertTrue(subject.equals(new Subject("Mathematics")));
+
+        assertFalse(subject.equals(null));
+        assertFalse(subject.equals("Mathematics"));
+        assertFalse(subject.equals(new Subject("English")));
+    }
+
+    @Test
+    public void hashCodeMethod() {
+        Subject subject = new Subject("Mathematics");
+        assertEquals(subject.hashCode(), new Subject("Mathematics").hashCode());
+    }
+}


### PR DESCRIPTION
Add Subject field class (alphanumeric validation) and PaymentStatus field class (Paid/Due/Overdue enum-like validation) to support the Registering Students feature. Both classes follow existing AB3 field patterns with immutability, null checks, and validation.