### PR TITLE
Add EmergencyContact model class with tests

### DIFF
--- a/src/main/java/seedu/address/model/person/EmergencyContact.java
+++ b/src/main/java/seedu/address/model/person/EmergencyContact.java
@@ -1,0 +1,60 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a student's emergency contact number.
+ * Guarantees: immutable; is valid as declared in {@link #isValidEmergencyContact(String)}
+ */
+public class EmergencyContact {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Emergency contact should be exactly 8 digits";
+
+    public static final String VALIDATION_REGEX = "\\d{8}";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code EmergencyContact}.
+     *
+     * @param contact A valid 8-digit emergency contact number.
+     */
+    public EmergencyContact(String contact) {
+        requireNonNull(contact);
+        checkArgument(isValidEmergencyContact(contact), MESSAGE_CONSTRAINTS);
+        value = contact;
+    }
+
+    /**
+     * Returns true if a given string is a valid emergency contact number.
+     */
+    public static boolean isValidEmergencyContact(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof EmergencyContact)) {
+            return false;
+        }
+
+        EmergencyContact otherContact = (EmergencyContact) other;
+        return value.equals(otherContact.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/model/person/EmergencyContactTest.java
+++ b/src/test/java/seedu/address/model/person/EmergencyContactTest.java
@@ -1,0 +1,63 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class EmergencyContactTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new EmergencyContact(null));
+    }
+
+    @Test
+    public void constructor_invalidContact_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact(""));
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("1234567"));
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("123456789"));
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("abcdefgh"));
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("1234 567"));
+    }
+
+    @Test
+    public void isValidEmergencyContact() {
+        assertFalse(EmergencyContact.isValidEmergencyContact(""));
+        assertFalse(EmergencyContact.isValidEmergencyContact("1234567"));
+        assertFalse(EmergencyContact.isValidEmergencyContact("123456789"));
+        assertFalse(EmergencyContact.isValidEmergencyContact("abcdefgh"));
+        assertFalse(EmergencyContact.isValidEmergencyContact("1234 5678"));
+
+        assertTrue(EmergencyContact.isValidEmergencyContact("91234567"));
+        assertTrue(EmergencyContact.isValidEmergencyContact("00000000"));
+        assertTrue(EmergencyContact.isValidEmergencyContact("99999999"));
+    }
+
+    @Test
+    public void toStringMethod() {
+        EmergencyContact contact = new EmergencyContact("91234567");
+        assertEquals("91234567", contact.toString());
+    }
+
+    @Test
+    public void equals() {
+        EmergencyContact contact = new EmergencyContact("91234567");
+
+        assertTrue(contact.equals(contact));
+        assertTrue(contact.equals(new EmergencyContact("91234567")));
+
+        assertFalse(contact.equals(null));
+        assertFalse(contact.equals("91234567"));
+        assertFalse(contact.equals(new EmergencyContact("98765432")));
+    }
+
+    @Test
+    public void hashCodeMethod() {
+        EmergencyContact contact = new EmergencyContact("91234567");
+        assertEquals(contact.hashCode(),
+                new EmergencyContact("91234567").hashCode());
+    }
+}


### PR DESCRIPTION
Add EmergencyContact field class (8-digit validation) to support the Registering Students feature. Follows existing AB3 field patterns with immutability, null checks, and validation. This replaces Phone as the contact field for student records.