### PR TITLE
[Docs] Add User Guide section for markattendance command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -295,6 +295,7 @@ _Details coming soon ..._
 | **Help**   | `help` |
 | **List**   | `list` |
 | **Mark**   | `mark INDEX ps/PAYMENT_STATUS` <br> e.g., `mark 1 ps/Paid` |
+| **MarkAttendance** | `markattendance INDEX s/SUBJECT l/LESSON st/STATUS` <br> e.g., `markattendance 1 s/Mathematics l/Algebra Lesson 5 st/Present` |
 | **Remark** | `remark INDEX r/REMARK` <br> e.g., `remark 1 r/Needs help with algebra` |
 | **View**   | `view INDEX` <br> e.g., `view 1` |
 


### PR DESCRIPTION
Summary

Fixes issue #109 
Adds a ### Marking attendance: \markattendance`section in the Features section, placed betweenmarkanddelete`
Adds l/ (Lesson) and st/ (Attendance Status) rows to the parameter constraints table
Adds MarkAttendance entry to the Command Summary table
Includes a MarkBind caution box covering the subject-enrollment requirement, display-relative index, and case-insensitive status input