### PR TITLE
docs: Add User Guide documentation for listattendance command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -315,7 +315,9 @@ _Details coming soon ..._
 | **Find**   | `find [n/NAME] [s/SUBJECT] [d/DAY] [ps/STATUS] [t/TAG]` <br> e.g., `find s/Mathematics d/Monday` |
 | **Help**   | `help` |
 | **List**   | `list` |
+| **ListAttendance** | `listattendance INDEX [s/SUBJECT]` <br> e.g., `listattendance 1 s/Mathematics` |
 | **Mark**   | `mark INDEX ps/PAYMENT_STATUS` <br> e.g., `mark 1 ps/Paid` |
+| **MarkAttendance** | `markattendance INDEX s/SUBJECT l/LESSON st/STATUS` <br> e.g., `markattendance 1 s/Mathematics l/Algebra Lesson 5 st/Present` |
 | **Remark** | `remark INDEX r/REMARK` <br> e.g., `remark 1 r/Needs help with algebra` |
 | **View**   | `view INDEX` <br> e.g., `view 1` |
 


### PR DESCRIPTION
Closes #111 

Adds ### Viewing attendance records: listattendance section with format, parameters, behaviour notes, tip box, and examples
Adds ListAttendance and MarkAttendance rows to the Command Summary table