### PR TITLE
test: Add remark coverage for EditCommand and EditCommandParser

### DIFF
--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
@@ -48,6 +49,9 @@ public class CommandTestUtil {
     public static final String VALID_TIME_0900 = "0900";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_REMARK_AMY = "Needs extra help";
+    public static final String REMARK_DESC_AMY = " " + PREFIX_REMARK
+            + VALID_REMARK_AMY;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME
             + VALID_NAME_AMY;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMERGENCY_CONTACT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -86,6 +87,29 @@ public class EditCommandTest {
 
         assertCommandSuccess(editCommand, model,
                 expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_remarkFieldSpecified_success() {
+        Person personToEdit = model.getFilteredPersonList()
+                .get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(personToEdit)
+                .withRemark(VALID_REMARK_AMY).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withRemark(VALID_REMARK_AMY).build();
+        EditCommand editCommand =
+                new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(
+                new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personToEdit, editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -25,11 +25,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMERGENCY_CONTACT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMERGENCY_CONTACT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.REMARK_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -200,6 +203,13 @@ public class EditCommandParserTest {
                 .withTags(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
+
+        // remark
+        userInput = targetIndex.getOneBased() + REMARK_DESC_AMY;
+        descriptor = new EditPersonDescriptorBuilder()
+                .withRemark(VALID_REMARK_AMY).build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
@@ -244,6 +254,12 @@ public class EditCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(
                         PREFIX_EMERGENCY_CONTACT, PREFIX_EMAIL,
                         PREFIX_ADDRESS));
+
+        // duplicate remark
+        userInput = targetIndex.getOneBased()
+                + REMARK_DESC_AMY + REMARK_DESC_AMY;
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_REMARK));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -12,6 +12,7 @@ import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.PaymentStatus;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Remark;
 import seedu.address.model.person.Subject;
 import seedu.address.model.person.Time;
 import seedu.address.model.tag.Tag;
@@ -95,6 +96,14 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withPaymentStatus(String status) {
         descriptor.setPaymentStatus(new PaymentStatus(status));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Remark} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withRemark(String remark) {
+        descriptor.setRemark(new Remark(remark));
         return this;
     }
 


### PR DESCRIPTION
## Summary

Addresses Codecov patch coverage gap from the EditCommand remark fix.

- Added `withRemark()` to `EditPersonDescriptorBuilder`
- Added `VALID_REMARK_AMY` / `REMARK_DESC_AMY` constants to `CommandTestUtil`
- Added remark parse test to `EditCommandParserTest` (`parse_oneFieldSpecified_success`)
- Added duplicate remark rejection test to `EditCommandParserTest` (`parse_multipleRepeatedFields_failure`)
- Added `execute_remarkFieldSpecified_success` to `EditCommandTest`

## Test plan

- [x] `./gradlew test` passes
- [x] Covers the `PREFIX_REMARK` parsing block and `updatedRemark` branch in `createEditedPerson()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)