### PR TITLE
fix: widen EmergencyContact to accept landlines and short codes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -122,7 +122,7 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 | `n/` | Name | Alphanumeric characters and spaces, cannot be blank |
 | `e/` | Email | Valid email format (e.g., `user@example.com`) |
 | `a/` | Address | Any text, cannot be blank |
-| `ec/` | Emergency Contact | Exactly 8 digits, must start with 8 or 9 (valid Singapore mobile number) |
+| `ec/` | Emergency Contact | A 3 to 15 digit number (e.g., mobile, landline, or short code such as 999) |
 | `s/` | Subject | Alphanumeric characters and spaces; must not be blank |
 | `d/` | Day | Monday-Sunday (or Mon-Sun), case-insensitive |
 | `ti/` | Time | 4-digit 24-hour format, 0000-2359 |

--- a/src/main/java/seedu/address/model/person/EmergencyContact.java
+++ b/src/main/java/seedu/address/model/person/EmergencyContact.java
@@ -10,16 +10,16 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class EmergencyContact {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Emergency contact should be a valid Singapore number: 8 digits starting with 8 or 9";
+            "Emergency contact must be a 3 to 15 digit number (may be a landline or short code).";
 
-    public static final String VALIDATION_REGEX = "[89]\\d{7}";
+    public static final String VALIDATION_REGEX = "\\d{3,15}";
 
     public final String value;
 
     /**
      * Constructs an {@code EmergencyContact}.
      *
-     * @param contact A valid 8-digit emergency contact number.
+     * @param contact A valid emergency contact number (3 to 15 digits).
      */
     public EmergencyContact(String contact) {
         requireNonNull(contact);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -96,7 +96,7 @@ public class CommandTestUtil {
             + "bob!yahoo";
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS;
     public static final String INVALID_EMERGENCY_CONTACT_DESC = " "
-            + PREFIX_EMERGENCY_CONTACT + "911";
+            + PREFIX_EMERGENCY_CONTACT + "12";
     public static final String INVALID_PAYMENT_STATUS_DESC = " "
             + PREFIX_PAYMENT_STATUS + "Unknown";
     public static final String INVALID_DAY_DESC = " " + PREFIX_DAY

--- a/src/test/java/seedu/address/model/person/EmergencyContactTest.java
+++ b/src/test/java/seedu/address/model/person/EmergencyContactTest.java
@@ -17,35 +17,37 @@ public class EmergencyContactTest {
     @Test
     public void constructor_invalidContact_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new EmergencyContact(""));
-        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("1234567"));
-        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("123456789"));
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("12"));
+        assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("1234567890123456"));
         assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("abcdefgh"));
         assertThrows(IllegalArgumentException.class, () -> new EmergencyContact("1234 567"));
     }
 
     @Test
     public void isValidEmergencyContact() {
-        // invalid: wrong length
+        // invalid: too short (fewer than 3 digits)
         assertFalse(EmergencyContact.isValidEmergencyContact(""));
-        assertFalse(EmergencyContact.isValidEmergencyContact("9123456"));
-        assertFalse(EmergencyContact.isValidEmergencyContact("912345678"));
+        assertFalse(EmergencyContact.isValidEmergencyContact("12"));
+
+        // invalid: too long (more than 15 digits)
+        assertFalse(EmergencyContact.isValidEmergencyContact("1234567890123456"));
 
         // invalid: non-digit characters
         assertFalse(EmergencyContact.isValidEmergencyContact("abcdefgh"));
         assertFalse(EmergencyContact.isValidEmergencyContact("9234 567"));
 
-        // invalid: does not start with 8 or 9
-        assertFalse(EmergencyContact.isValidEmergencyContact("00000000"));
-        assertFalse(EmergencyContact.isValidEmergencyContact("11111111"));
-        assertFalse(EmergencyContact.isValidEmergencyContact("71234567"));
+        // valid: short code (3 digits)
+        assertTrue(EmergencyContact.isValidEmergencyContact("999"));
 
-        // valid: starts with 8
+        // valid: landline (does not start with 8 or 9)
+        assertTrue(EmergencyContact.isValidEmergencyContact("61234567"));
+
+        // valid: standard Singapore mobile
         assertTrue(EmergencyContact.isValidEmergencyContact("81234567"));
-        assertTrue(EmergencyContact.isValidEmergencyContact("88888888"));
-
-        // valid: starts with 9
         assertTrue(EmergencyContact.isValidEmergencyContact("91234567"));
-        assertTrue(EmergencyContact.isValidEmergencyContact("99999999"));
+
+        // valid: maximum length (15 digits)
+        assertTrue(EmergencyContact.isValidEmergencyContact("123456789012345"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes #233 (and closes #224 — same root cause)
- Change `VALIDATION_REGEX` from `[89]\d{7}` to `\d{3,15}` so landlines, short codes (e.g. `999`), and international numbers are accepted
- Update `MESSAGE_CONSTRAINTS` to reflect the new rule
- Update UG parameter table for `ec/` to match

## Test plan
- [ ] `add … ec/999` succeeds
- [ ] `add … ec/61234567` (landline) succeeds
- [ ] `add … ec/98765432` (mobile) still succeeds
- [ ] `add … ec/abc` still rejected
- [ ] `./gradlew test` passes with updated `EmergencyContactTest`