### PR TITLE
fix: require at least one prefix for find command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -51,9 +51,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                 || argMultimap.getValue(PREFIX_TAG).isPresent();
 
         if (!hasPrefixes) {
-            // If no supported prefixes are provided, interpret the input as a name search.
-            String[] nameKeywords = argMultimap.getPreamble().split("\\s+");
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         } else {
             if (!argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -96,11 +96,11 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                        FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                        FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
 
         FindCommand mixedCaseCommand = (FindCommand) parser.parseCommand(
-                        "FiNd " + keywords.stream().collect(Collectors.joining(" ")));
+                        "FiNd n/" + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), mixedCaseCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -33,14 +33,14 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
-
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    public void parse_noPrefixArgs_throwsParseException() {
+        // bare keywords without any prefix are no longer accepted
+        assertParseFailure(parser, "Alice Bob",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "S",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " \n Alice \n \t Bob  \t",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes #259
- `find S` (and any bare keyword without a recognized prefix) now returns an error with `MESSAGE_USAGE` instead of silently returning results
- `find n/S`, `find ps/Due`, etc. still work as before

## Test plan
- [ ] `find S` → shows usage error
- [ ] `find n/S` → still returns substring name matches
- [ ] `find ps/Due` → still works
- [ ] `./gradlew test` passes