### PR TITLE
docs: fix PE-D UG inconsistencies (#218 #219)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,5 +1,4 @@
 ---
-
 layout: default.md
 title: "User Guide"
 pageNav: 3
@@ -27,44 +26,44 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 
 ## Useful Notations and Glossary
 
-| Term | Definition |
-|------|------------|
-| **GUI** | Graphical User Interface — the visual display of the application (windows, buttons, etc.) |
-| **CLI** | Command Line Interface — a text-based interface where you type commands to interact with the app |
-| **Command** | An instruction typed into the command box to perform an action (e.g., `add`, `delete`) |
-| **Parameter** | A value supplied to a command, indicated by a prefix (e.g., `n/John` where `John` is the parameter) |
-| **Index** | The number shown beside a student in the displayed list, used to refer to that student in commands |
-| **Mainstream OS** | Windows, macOS, and Linux operating systems |
-| **Tutor** | The user of TutorCentral — a freelance tutor managing their students |
-| **Student** | A person being tutored, whose information is stored in TutorCentral |
+| Term                  | Definition                                                                                                              |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **GUI**               | Graphical User Interface — the visual display of the application (windows, buttons, etc.)                               |
+| **CLI**               | Command Line Interface — a text-based interface where you type commands to interact with the app                        |
+| **Command**           | An instruction typed into the command box to perform an action (e.g., `add`, `delete`)                                  |
+| **Parameter**         | A value supplied to a command, indicated by a prefix (e.g., `n/John` where `John` is the parameter)                     |
+| **Index**             | The number shown beside a student in the displayed list, used to refer to that student in commands                      |
+| **Mainstream OS**     | Windows, macOS, and Linux operating systems                                                                             |
+| **Tutor**             | The user of TutorCentral — a freelance tutor managing their students                                                    |
+| **Student**           | A person being tutored, whose information is stored in TutorCentral                                                     |
 | **Emergency Contact** | A valid 8-digit Singapore phone number (starting with 8 or 9) of a person to contact in case of emergency for a student |
-| **Attendance** | A record of whether a student was present, absent, or excused for a lesson |
-| **Attendance Status** | One of: `Present`, `Absent`, or `Excused` — indicates a student's attendance for a specific lesson |
-| **Payment Status** | One of: `Paid`, `Due`, or `Overdue` — indicates the current fee payment status of a student |
-| **Subject** | An academic subject a student is enrolled in (e.g., `Mathematics`, `English`) |
-| **Lesson Slot** | A scheduled tutoring session defined by a subject, day, and time (e.g., Mathematics on Monday at 1400) |
-| **Tag** | A short alphanumeric label attached to a student for categorisation (e.g., `priority`, `trial`) |
-| **Remark** | A free-text note attached to a student for any additional information |
+| **Attendance**        | A record of whether a student was present, absent, or excused for a lesson                                              |
+| **Attendance Status** | One of: `Present`, `Absent`, or `Excused` — indicates a student's attendance for a specific lesson                      |
+| **Payment Status**    | One of: `Paid`, `Due`, or `Overdue` — indicates the current fee payment status of a student                             |
+| **Subject**           | An academic subject a student is enrolled in (e.g., `Mathematics`, `English`)                                           |
+| **Lesson Slot**       | A scheduled tutoring session defined by a subject, day, and time (e.g., Mathematics on Monday at 1400)                  |
+| **Tag**               | A short alphanumeric label attached to a student for categorisation (e.g., `priority`, `trial`)                         |
+| **Remark**            | A free-text note attached to a student for any additional information                                                   |
 
 <!-- * Table of Contents -->
 <page-nav-print />
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## Notes for Users
 
-* **Launching the app:** Use `java -jar tutorcentral.jar` in a terminal rather than double-clicking the file, as double-clicking may not work on some systems.
-* **Folder permissions:** The app needs to create and update files such as `preferences.json` and the `data/` folder. Place the JAR in a normal user-writable folder such as `Documents`, `Desktop`, or a personal project folder. Avoid protected system folders or read-only shared folders.
-* **macOS fullscreen:** macOS users running the app in fullscreen mode may experience unexpected behaviour when opening secondary dialogs such as the Help window or the student view dialog. Use windowed mode instead.
+- **Launching the app:** Use `java -jar tutorcentral.jar` in a terminal rather than double-clicking the file, as double-clicking may not work on some systems.
+- **Folder permissions:** The app needs to create and update files such as `preferences.json` and the `data/` folder. Place the JAR in a normal user-writable folder such as `Documents`, `Desktop`, or a personal project folder. Avoid protected system folders or read-only shared folders.
+- **macOS fullscreen:** macOS users running the app in fullscreen mode may experience unexpected behaviour when opening secondary dialogs such as the Help window or the student view dialog. Use windowed mode instead.
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## Quick start
 
 1. Ensure you have Java `17` installed in your Computer. Follow the instructions for your OS:
-   * **Windows:** Download and install [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/#java17) or [Adoptium Temurin 17](https://adoptium.net/temurin/releases/?version=17).
-   * **Mac:** Follow the precise installation steps in the [Mac installation guide](https://se-education.org/guides/tutorials/javaInstallationMac.html) on se-education.org. Alternatively, download [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/#java17) or [Adoptium Temurin 17](https://adoptium.net/temurin/releases/?version=17).
-   * **Linux:** Run `sudo apt install openjdk-17-jdk`, or download binaries from [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/#java17) or [Adoptium Temurin 17](https://adoptium.net/temurin/releases/?version=17).
+   - **Windows:** Download and install [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/#java17) or [Adoptium Temurin 17](https://adoptium.net/temurin/releases/?version=17).
+   - **Mac:** Follow the precise installation steps in the [Mac installation guide](https://se-education.org/guides/tutorials/javaInstallationMac.html) on se-education.org. Alternatively, download [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/#java17) or [Adoptium Temurin 17](https://adoptium.net/temurin/releases/?version=17).
+   - **Linux:** Run `sudo apt install openjdk-17-jdk`, or download binaries from [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/#java17) or [Adoptium Temurin 17](https://adoptium.net/temurin/releases/?version=17).
 
 2. Download the latest `.jar` file from [here](https://github.com/AY2526S2-CS2103T-T09-2/tp/releases).
 
@@ -76,20 +75,19 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 
 5. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
    Some example commands you can try:
+   - `list` : Lists all students.
 
-   * `list` : Lists all students.
+   - `add n/John Doe e/johnd@example.com a/John street, block 123, #01-01 ec/98765432` : Adds a student named `John Doe` to Tutor Central.
 
-   * `add n/John Doe e/johnd@example.com a/John street, block 123, #01-01 ec/98765432` : Adds a student named `John Doe` to Tutor Central.
+   - `delete 3` : Deletes the 3rd student shown in the current list.
 
-   * `delete 3` : Deletes the 3rd student shown in the current list.
+   - `clear` : Deletes all students.
 
-   * `clear` : Deletes all students.
-
-   * `exit` : Exits the app.
+   - `exit` : Exits the app.
 
 6. Refer to the [Features](#features) below for details of each command.
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## Features
 
@@ -97,39 +95,39 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 
 **Notes about the command format:**<br>
 
-* Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
+- Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
-* Items in square brackets are optional.<br>
+- Items in square brackets are optional.<br>
   e.g. `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
-* Items with `…`​ after them can be used multiple times including zero times.<br>
+- Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
-* Parameters can be in any order.<br>
+- Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME e/EMAIL`, `e/EMAIL n/NAME` is also acceptable.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
+- Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
-* If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
-</box>
+- If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
+  </box>
 
 **Parameter constraints:**
 
-| Prefix | Field | Rules |
-|--------|-------|-------|
-| `n/` | Name | Alphanumeric characters and spaces, cannot be blank |
-| `e/` | Email | Valid email format (e.g., `user@example.com`) |
-| `a/` | Address | Any text, cannot be blank |
-| `ec/` | Emergency Contact | Exactly 8 digits, must start with 8 or 9 (valid Singapore mobile number) |
-| `s/` | Subject | Alphanumeric characters and spaces; must not be blank |
-| `d/` | Day | Monday-Sunday (or Mon-Sun), case-insensitive |
-| `ti/` | Time | 4-digit 24-hour format, 0000-2359 |
-| `ps/` | Payment Status | One of: `Paid`, `Due`, `Overdue` |
-| `t/` | Tag | Alphanumeric characters, no spaces |
-| `r/` | Remark | Any text (free-form) |
-| `st/` | Attendance Status | One of: `Present`, `Absent`, `Excused` |
+| Prefix | Field             | Rules                                                                    |
+| ------ | ----------------- | ------------------------------------------------------------------------ |
+| `n/`   | Name              | Alphanumeric characters and spaces, cannot be blank                      |
+| `e/`   | Email             | Valid email format (e.g., `user@example.com`)                            |
+| `a/`   | Address           | Any text, cannot be blank                                                |
+| `ec/`  | Emergency Contact | Exactly 8 digits, must start with 8 or 9 (valid Singapore mobile number) |
+| `s/`   | Subject           | Alphanumeric characters and spaces; must not be blank                    |
+| `d/`   | Day               | Monday-Sunday (or Mon-Sun), case-insensitive                             |
+| `ti/`  | Time              | 4-digit 24-hour format, 0000-2359                                        |
+| `ps/`  | Payment Status    | One of: `Paid`, `Due`, `Overdue`                                         |
+| `t/`   | Tag               | Alphanumeric characters, no spaces                                       |
+| `r/`   | Remark            | Any text (free-form)                                                     |
+| `st/`  | Attendance Status | One of: `Present`, `Absent`, `Excused`                                   |
 
 **Important:** Subjects, days, and times must be specified in matching triplets. Each subject requires a corresponding day and time. If you provide 2 subjects, you must provide exactly 2 days and 2 times.
 
@@ -140,7 +138,6 @@ Shows a message explaining how to access the help page.
 Format: `help`
 
 Example result: A pop-up window will show you a link to this user guide with more detailed instructions.
-
 
 ### Adding a student: `add`
 
@@ -153,16 +150,16 @@ Format: `add n/NAME e/EMAIL a/ADDRESS ec/EMERGENCY_CONTACT [s/SUBJECT d/DAY ti/T
 **Tip:** A student can have any number of tags (including 0)
 </box>
 
-* You can clear all lesson slots only by providing `s/ d/ ti/` with no values after each prefix, for example `edit 1 s/ d/ ti/`.
+- You can clear all lesson slots only by providing `s/ d/ ti/` with no values after each prefix, for example `edit 1 s/ d/ ti/`.
 
 Examples:
-* `add n/John Tan e/johnt@example.com a/311, Clementi Ave 2, #02-25 ec/98765432 s/Mathematics d/Monday ti/1400 s/English d/Wednesday ti/1600 ps/Due`
+
+- `add n/John Tan e/johntan@example.com a/21 Lower Kent Ridge Rd ec/98765432 s/Mathematics d/Monday ti/1400 s/English d/Wednesday ti/1600 ps/Due`
 
 If `ps/PAYMENT_STATUS` is omitted, the student's payment status defaults to `Due`.
 
 Example result after adding a student:
 ![add result](images/add-result.png)
-
 
 ### Listing all students : `list`
 
@@ -185,18 +182,19 @@ Format: `edit INDEX [n/NAME] [e/EMAIL] [a/ADDRESS] [ec/EMERGENCY_CONTACT] [s/SUB
 
 </box>
 
-* Edits the student at the specified `INDEX`. The index refers to the index number shown in the displayed student list. The index **must be a positive integer** 1, 2, 3, …​
-* At least one of the optional fields must be provided.
-* Existing values will be updated to the input values.
-* When editing tags, the existing tags of the student will be removed i.e. adding of tags is not cumulative.
-* You can remove all the student’s tags by typing `t/` without
-    specifying any tags after it.
-* You can remove all lesson slots by typing `s/ d/ ti/` without specifying any values after the prefixes.
+- Edits the student at the specified `INDEX`. The index refers to the index number shown in the displayed student list. The index **must be a positive integer** 1, 2, 3, …​
+- At least one of the optional fields must be provided.
+- Existing values will be updated to the input values.
+- When editing tags, the existing tags of the student will be removed i.e. adding of tags is not cumulative.
+- You can remove all the student’s tags by typing `t/` without
+  specifying any tags after it.
+- You can remove all lesson slots by typing `s/ d/ ti/` without specifying any values after the prefixes.
 
 Examples:
-*  `edit 1 e/johndoe@example.com` Edits the email address of the 1st student to be `johndoe@example.com`.
-*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd student to be `Betsy Crower` and clears all existing tags.
-*  `edit 1 s/ d/ ti/` Clears all lesson slots of the 1st student.
+
+- `edit 1 e/johndoe@example.com` Edits the email address of the 1st student to be `johndoe@example.com`.
+- `edit 2 n/Betsy Crower t/` Edits the name of the 2nd student to be `Betsy Crower` and clears all existing tags.
+- `edit 1 s/ d/ ti/` Clears all lesson slots of the 1st student.
 
 Example result:
 ![edit result](images/edit-result.png)
@@ -207,24 +205,25 @@ Finds students matching the given criteria.
 
 Format: `find [n/NAME_KEYWORDS] [s/SUBJECT] [d/DAY] [ps/PAYMENT_STATUS] [t/TAG]`
 
-* You can still search by name without prefixes using `find KEYWORD [MORE_KEYWORDS]`.
-* When using prefixes, multiple criteria use AND logic.
-* Repeating the same prefix combines all supplied values for that field.
-* You can provide multiple keywords after a single prefix, or repeat the same prefix multiple times.
-* Name search is case-insensitive and matches full words only.
-* Subject and tag searches are case-insensitive and match partial words.
-* Day and payment status searches are case-insensitive exact matches.
-* Payment status must be one of: `Paid`, `Due`, `Overdue`.
+- You can still search by name without prefixes using `find KEYWORD [MORE_KEYWORDS]`.
+- When using prefixes, multiple criteria use AND logic.
+- Repeating the same prefix combines all supplied values for that field.
+- You can provide multiple keywords after a single prefix, or repeat the same prefix multiple times.
+- Name search is case-insensitive and matches full words only.
+- Subject and tag searches are case-insensitive and match partial words.
+- Day and payment status searches are case-insensitive exact matches.
+- Payment status must be one of: `Paid`, `Due`, `Overdue`.
 
 Examples:
-* `find John` returns `john` and `John Doe`
-* `find s/Mathematics` returns all students taking Mathematics
-* `find s/Math s/English` returns students taking Math or English
-* `find d/Monday` returns all students with Monday lessons
-* `find n/Alice Bob n/Carol` returns students whose names match Alice, Bob, or Carol
-* `find ps/Due` returns all students with unpaid fees
-* `find s/Math d/Monday` returns students taking Math on Mondays
-* `find t/priority` returns students tagged as priority
+
+- `find John` returns `john` and `John Doe`
+- `find s/Mathematics` returns all students taking Mathematics
+- `find s/Math s/English` returns students taking Math or English
+- `find d/Monday` returns all students with Monday lessons
+- `find n/Alice Bob n/Carol` returns students whose names match Alice, Bob, or Carol
+- `find ps/Due` returns all students with unpaid fees
+- `find s/Math d/Monday` returns students taking Math on Mondays
+- `find t/priority` returns students tagged as priority
 
 Example result for name-based search: `find John`
 ![find by name result](images/find-name-result.png)
@@ -240,12 +239,13 @@ Shows the full details of the student at the given index, in a pop-up window.
 
 Format: `view INDEX`
 
-* The index refers to the index number shown in the displayed student list.
-* The index **must be a positive integer** 1, 2, 3, …​
+- The index refers to the index number shown in the displayed student list.
+- The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `view 1` shows the full details of the 1st student in the current list.
-* `find Alex` followed by `view 1` shows the full details of the 1st student in the filtered results.
+
+- `view 1` shows the full details of the 1st student in the current list.
+- `find Alex` followed by `view 1` shows the full details of the 1st student in the filtered results.
 
 Example result:
 ![view result](images/view-result.png)
@@ -256,14 +256,15 @@ Adds or updates a free-text remark for the student at the given index. Useful fo
 
 Format: `remark INDEX r/REMARK`
 
-* The index refers to the index number shown in the displayed student list.
-* The index **must be a positive integer** 1, 2, 3, ...
-* The remark replaces any existing remark for that student.
-* To remove a remark, use `remark INDEX r/` with nothing after `r/`.
+- The index refers to the index number shown in the displayed student list.
+- The index **must be a positive integer** 1, 2, 3, ...
+- The remark replaces any existing remark for that student.
+- To remove a remark, use `remark INDEX r/` with nothing after `r/`.
 
 Examples:
-* `remark 1 r/Needs extra help with algebra` adds a remark to the 1st student.
-* `remark 2 r/` removes the remark from the 2nd student.
+
+- `remark 1 r/Needs extra help with algebra` adds a remark to the 1st student.
+- `remark 2 r/` removes the remark from the 2nd student.
 
 Example result:
 ![remark result](images/remark-result.png)
@@ -274,14 +275,15 @@ Quickly updates the payment status of a student.
 
 Format: `mark INDEX ps/PAYMENT_STATUS`
 
-* The index refers to the index number shown in the displayed student list.
-* The index **must be a positive integer** 1, 2, 3, ...
-* Payment status must be one of: `Paid`, `Due`, `Overdue`.
-* Payment status is case-insensitive, so `paid`, `PAID`, and `Paid` are all accepted.
+- The index refers to the index number shown in the displayed student list.
+- The index **must be a positive integer** 1, 2, 3, ...
+- Payment status must be one of: `Paid`, `Due`, `Overdue`.
+- Payment status is case-insensitive, so `paid`, `PAID`, and `Paid` are all accepted.
 
 Examples:
-* `mark 1 ps/Overdue` marks the 1st student's payment as Overdue.
-* `mark 3 ps/Paid` marks the 3rd student's payment as Paid.
+
+- `mark 1 ps/Overdue` marks the 1st student's payment as Overdue.
+- `mark 3 ps/Paid` marks the 3rd student's payment as Paid.
 
 Example result:
 ![mark result](images/mark-result.png)
@@ -292,27 +294,30 @@ Records a student's attendance for a specific lesson within a subject.
 
 Format: `markattendance INDEX s/SUBJECT d/DAY ti/TIME st/STATUS`
 
-* The index refers to the index number shown in the displayed student list.
-* The index **must be a positive integer** 1, 2, 3, ...
-* The student must have a lesson slot matching the specified subject, day, and time combination. Subject matching is case-insensitive.
-* If an attendance record already exists for that subject and time slot, it is updated.
-* If no record exists, a new one is created.
+- The index refers to the index number shown in the displayed student list.
+- The index **must be a positive integer** 1, 2, 3, ...
+- The student must have a lesson slot matching the specified subject, day, and time combination. Subject matching is case-insensitive.
+- If an attendance record already exists for that subject and time slot, it is updated.
+- If no record exists, a new one is created.
 
 <box type="warning" seamless>
 
 **Caution:**
-* The student must have a matching lesson slot (subject + day + time) before attendance can be marked. Else, the command is blocked.
-* The `INDEX` refers to the position in the **currently displayed list** — use `list` or `find` first if needed.
-* Attendance status (`st/`) is case-insensitive (e.g., `present`, `Present`, and `PRESENT` are all accepted).
-</box>
+
+- The student must have a matching lesson slot (subject + day + time) before attendance can be marked. Else, the command is blocked.
+- The `INDEX` refers to the position in the **currently displayed list** — use `list` or `find` first if needed.
+- Attendance status (`st/`) is case-insensitive (e.g., `present`, `Present`, and `PRESENT` are all accepted).
+  </box>
 
 Examples:
-* `markattendance 1 s/Mathematics d/Monday ti/1400 st/Absent` marks the 1st student as Absent for their Mathematics lesson on Monday at 1400.
+
+- `markattendance 1 s/Mathematics d/Monday ti/1400 st/Absent` marks the 1st student as Absent for their Mathematics lesson on Monday at 1400.
 
 Example result:
 ![view result](images/markattendance-result.png)
-* `markattendance 1 s/Mathematics d/Monday ti/1400 st/Excused` can update the same record to Excused (e.g., after receiving an MC).
-* `markattendance 3 s/Mathematics d/Tuesday ti/0900 st/Present` is blocked, since the third student does not have a lesson slot for Mathematics on Tuesday at 0900.
+
+- `markattendance 1 s/Mathematics d/Monday ti/1400 st/Excused` can update the same record to Excused (e.g., after receiving an MC).
+- `markattendance 3 s/Mathematics d/Tuesday ti/0900 st/Present` is blocked, since the third student does not have a lesson slot for Mathematics on Tuesday at 0900.
 
 Example result:
 ![view result](images/markattendance-error.png)
@@ -323,11 +328,11 @@ Displays a student's attendance records, optionally filtered by subject.
 
 Format: `listattendance INDEX [s/SUBJECT]`
 
-* The index refers to the index number shown in the displayed student list.
-* The index **must be a positive integer** 1, 2, 3, ...
-* If `s/SUBJECT` is provided, only attendance records for that subject are shown (case-insensitive).
-* Results are organised by subject and lesson in the result display area.
-* If no attendance records exist, a message indicates this.
+- The index refers to the index number shown in the displayed student list.
+- The index **must be a positive integer** 1, 2, 3, ...
+- If `s/SUBJECT` is provided, only attendance records for that subject are shown (case-insensitive).
+- Results are organised by subject and lesson in the result display area.
+- If no attendance records exist, a message indicates this.
 
 <box type="tip" seamless>
 
@@ -336,8 +341,9 @@ Format: `listattendance INDEX [s/SUBJECT]`
 </box>
 
 Examples:
-* `listattendance 1` shows all attendance records for the 1st student.
-* `listattendance 1 s/Mathematics` shows only Mathematics attendance records for the 1st student.
+
+- `listattendance 1` shows all attendance records for the 1st student.
+- `listattendance 1 s/Mathematics` shows only Mathematics attendance records for the 1st student.
 
 Example result:
 ![view result](images/listattendance-result.png)
@@ -348,16 +354,17 @@ Deletes the specified student from Tutor Central.
 
 Format: `delete INDEX`
 
-* Deletes the student at the specified `INDEX`.
-* The index refers to the index number shown in the displayed student list.
-* The index **must be a plain positive integer** 1, 2, 3, …​
-* Inputs such as `+2` and `1.0` are not supported.
-* The command only accepts one index input at a time.
-* After a successful deletion, Tutor Central shows the full student list again.
+- Deletes the student at the specified `INDEX`.
+- The index refers to the index number shown in the displayed student list.
+- The index **must be a plain positive integer** 1, 2, 3, …​
+- Inputs such as `+2` and `1.0` are not supported.
+- The command only accepts one index input at a time.
+- After a successful deletion, Tutor Central shows the full student list again.
 
 Examples:
-* `list` followed by `delete 2` deletes the 2nd student in Tutor Central.
-* `find Betsy` followed by `delete 1` deletes the 1st student in the results of the `find` command.
+
+- `list` followed by `delete 2` deletes the 2nd student in Tutor Central.
+- `find Betsy` followed by `delete 1` deletes the 1st student in the results of the `find` command.
 
 Example result:
 ![delete result](images/delete-result.png)
@@ -385,7 +392,7 @@ TutorCentral data are saved automatically as a JSON file `[JAR file location]/da
 <box type="warning" seamless>
 
 **Caution:**
-If your changes to the data file makes its format invalid, TutorCentral will discard all data and start with an empty data file at the next run.  Hence, it is recommended to take a backup of the file before editing it.<br>
+If your changes to the data file makes its format invalid, TutorCentral will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
 Furthermore, certain edits can cause the TutorCentral to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </box>
 
@@ -393,7 +400,7 @@ Furthermore, certain edits can cause the TutorCentral to behave in unexpected wa
 
 _Details coming soon ..._
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## FAQ
 
@@ -418,7 +425,7 @@ _Details coming soon ..._
 **Q**: Is TutorCentral free?<br>
 **A**: Yes, TutorCentral is free and open-source, built by NUS students for the tutor community.
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## Known issues
 
@@ -428,22 +435,22 @@ _Details coming soon ..._
 4. **Attendance records are stored per lesson slot (subject + day + time).** If a student's lesson slots are edited, attendance records for removed slots are deleted so that the saved attendance data stays aligned with the student's current lesson schedule.
 5. **On macOS fullscreen mode, secondary dialogs may behave unexpectedly.** Commands that open separate windows, such as `help` and `view`, may not display as expected while the app is in fullscreen. Use windowed mode if this happens.
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## Command summary
 
-| Action     | Format, Examples |
-|------------|------------------|
-| **Add**    | `add n/NAME e/EMAIL a/ADDRESS ec/EMERGENCY_CONTACT [s/SUBJECT d/DAY ti/TIME]... [ps/PAYMENT_STATUS] [t/TAG]...` <br> e.g., `add n/John Doe e/johnd@example.com a/Clementi Ave 2 ec/91234567 s/Mathematics d/Monday ti/1400 ps/Due` |
-| **Clear**  | `clear` |
-| **Delete** | `delete INDEX` <br> e.g., `delete 3` |
-| **Edit**   | `edit INDEX [n/NAME] [e/EMAIL] [a/ADDRESS] [ec/EMERGENCY_CONTACT] [s/SUBJECT d/DAY ti/TIME]... [ps/PAYMENT_STATUS] [r/REMARK] [t/TAG]...` <br> e.g., `edit 1 e/johndoe@example.com` |
-| **Exit**   | `exit` |
-| **Find**   | `find [n/NAME] [s/SUBJECT] [d/DAY] [ps/PAYMENT_STATUS] [t/TAG]` <br> e.g., `find s/Mathematics d/Monday` |
-| **Help**   | `help` |
-| **List**   | `list` |
-| **ListAttendance** | `listattendance INDEX [s/SUBJECT]` <br> e.g., `listattendance 1 s/Mathematics` |
-| **Mark**   | `mark INDEX ps/PAYMENT_STATUS` <br> e.g., `mark 1 ps/Paid` |
-| **MarkAttendance** | `markattendance INDEX s/SUBJECT d/DAY ti/TIME st/STATUS` <br> e.g., `markattendance 1 s/Mathematics d/Monday ti/1400 st/Present` |
-| **Remark** | `remark INDEX r/REMARK` <br> e.g., `remark 1 r/Needs help with algebra` |
-| **View**   | `view INDEX` <br> e.g., `view 1` |
+| Action             | Format, Examples                                                                                                                                                                                                                   |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Add**            | `add n/NAME e/EMAIL a/ADDRESS ec/EMERGENCY_CONTACT [s/SUBJECT d/DAY ti/TIME]... [ps/PAYMENT_STATUS] [t/TAG]...` <br> e.g., `add n/John Doe e/johnd@example.com a/Clementi Ave 2 ec/91234567 s/Mathematics d/Monday ti/1400 ps/Due` |
+| **Clear**          | `clear`                                                                                                                                                                                                                            |
+| **Delete**         | `delete INDEX` <br> e.g., `delete 3`                                                                                                                                                                                               |
+| **Edit**           | `edit INDEX [n/NAME] [e/EMAIL] [a/ADDRESS] [ec/EMERGENCY_CONTACT] [s/SUBJECT d/DAY ti/TIME]... [ps/PAYMENT_STATUS] [r/REMARK] [t/TAG]...` <br> e.g., `edit 1 e/johndoe@example.com`                                                |
+| **Exit**           | `exit`                                                                                                                                                                                                                             |
+| **Find**           | `find [n/NAME] [s/SUBJECT] [d/DAY] [ps/PAYMENT_STATUS] [t/TAG]` <br> e.g., `find s/Mathematics d/Monday`                                                                                                                           |
+| **Help**           | `help`                                                                                                                                                                                                                             |
+| **List**           | `list`                                                                                                                                                                                                                             |
+| **ListAttendance** | `listattendance INDEX [s/SUBJECT]` <br> e.g., `listattendance 1 s/Mathematics`                                                                                                                                                     |
+| **Mark**           | `mark INDEX ps/PAYMENT_STATUS` <br> e.g., `mark 1 ps/Paid`                                                                                                                                                                         |
+| **MarkAttendance** | `markattendance INDEX s/SUBJECT d/DAY ti/TIME st/STATUS` <br> e.g., `markattendance 1 s/Mathematics d/Monday ti/1400 st/Present`                                                                                                   |
+| **Remark**         | `remark INDEX r/REMARK` <br> e.g., `remark 1 r/Needs help with algebra`                                                                                                                                                            |
+| **View**           | `view INDEX` <br> e.g., `view 1`                                                                                                                                                                                                   |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -53,7 +53,7 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 
 ## Notes for Users
 
-* **Launching the app:** Use `java -jar TutorCentral.jar` in a terminal rather than double-clicking the file, as double-clicking may not work on some systems.
+* **Launching the app:** Use `java -jar tutorcentral.jar` in a terminal rather than double-clicking the file, as double-clicking may not work on some systems.
 * **Folder permissions:** The app needs to create and update files such as `preferences.json` and the `data/` folder. Place the JAR in a normal user-writable folder such as `Documents`, `Desktop`, or a personal project folder. Avoid protected system folders or read-only shared folders.
 * **macOS fullscreen:** macOS users running the app in fullscreen mode may experience unexpected behaviour when opening secondary dialogs such as the Help window or the student view dialog. Use windowed mode instead.
 
@@ -156,7 +156,7 @@ Format: `add n/NAME e/EMAIL a/ADDRESS ec/EMERGENCY_CONTACT [s/SUBJECT d/DAY ti/T
 * You can clear all lesson slots only by providing `s/ d/ ti/` with no values after each prefix, for example `edit 1 s/ d/ ti/`.
 
 Examples:
-* `add n/John Doe e/johnd@example.com a/311, Clementi Ave 2, #02-25 ec/98765432 s/Mathematics d/Monday ti/1400 s/English d/Wednesday ti/1600 ps/Due`
+* `add n/John Tan e/johnt@example.com a/311, Clementi Ave 2, #02-25 ec/98765432 s/Mathematics d/Monday ti/1400 s/English d/Wednesday ti/1600 ps/Due`
 
 If `ps/PAYMENT_STATUS` is omitted, the student's payment status defaults to `Due`.
 


### PR DESCRIPTION
## Summary
- Fix #218: consistent lowercase `tutorcentral.jar` in Notes for Users.
- Fix #219: Features `add` example now uses `John Tan` to match the screenshot below it.
- #238 and #239 were resolved by the LessonSlot triplet refactor (f7e7fab1) — both examples parse cleanly now, so they'll be closed as stale.

## Test plan
- [x] Verified both UG examples parse through `AddCommandParser` without errors.
- [x] `./gradlew checkstyleMain checkstyleTest` passes (docs-only, no code changes).

Fixes #218
Fixes #219