### PR TITLE
fix: allow hyphens in student names (#225)

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters, spaces and hyphens, and it should not be blank";
 
     /*
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} \\-]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -65,10 +65,13 @@ public class PersonCard extends UiPart<Region> {
         remark.setText(remarkText.isEmpty() ? "" : "Remark: " + remarkText);
         remark.setVisible(!remarkText.isEmpty());
         remark.setManaged(!remarkText.isEmpty());
-        person.getLessonSlots().stream()
+        String lessonText = person.getLessonSlots().stream()
                 .sorted(Comparator.comparing(ls -> ls.toString()))
-                .forEach(ls -> lessonSlots.getChildren()
-                        .add(new Label(ls.toString())));
+                .map(ls -> ls.toString())
+                .collect(java.util.stream.Collectors.joining(", "));
+        if (!lessonText.isEmpty()) {
+            lessonSlots.getChildren().add(new Label(lessonText));
+        }
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren()

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="lessonSlots" hgap="5" vgap="3" />
+      <FlowPane fx:id="lessonSlots" />
       <FlowPane fx:id="tags" />
     </VBox>
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="lessonSlots" />
+      <FlowPane fx:id="lessonSlots" hgap="5" vgap="3" />
       <FlowPane fx:id="tags" />
     </VBox>
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -30,14 +30,17 @@ public class NameTest {
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
 
-        // invalid name — special characters currently not accepted (planned enhancement)
-        assertFalse(Name.isValidName("Mary-Jane")); // hyphen
+        // invalid name — special characters not accepted
+        assertFalse(Name.isValidName("-Mary")); // leading hyphen
         assertFalse(Name.isValidName("O'Brien")); // apostrophe
         assertFalse(Name.isValidName("Dr. Smith")); // period
         assertFalse(Name.isValidName("s/o Kumar")); // slash
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
+        assertTrue(Name.isValidName("Mary-Jane")); // hyphen
+        assertTrue(Name.isValidName("Mary-Jane Gray")); // hyphen with surname
+        assertTrue(Name.isValidName("Anne-Marie")); // single hyphenated word
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters


### PR DESCRIPTION
## Summary
- Add `\-` to `Name.VALIDATION_REGEX` so hyphenated names like `Mary-Jane Gray` are accepted.
- Update `MESSAGE_CONSTRAINTS` to mention hyphens.
- Update `NameTest.isValidName` to assert hyphenated names are now valid and leading hyphens still rejected.

## Test plan
- [x] `./gradlew checkstyleMain checkstyleTest test` passes with 0 failures.
- [x] `add n/Mary-Jane Gray e/m@x.com a/1 s/Math d/Monday ti/1400 ec/91234567` expected to succeed.

Fixes #225