### PR TITLE
fix: reject duplicate and overlapping lesson slots (#222 #236 #232 #256)

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -240,29 +240,29 @@ public class ParserUtil {
         requireNonNull(subjects);
         requireNonNull(days);
         requireNonNull(times);
-        List<LessonSlot> result = new ArrayList<>();
+        List<LessonSlot> lessonSlots = new ArrayList<>();
         for (int i = 0; i < subjects.size(); i++) {
             Subject subject = parseSubject(subjects.get(i));
             Day day = parseDay(days.get(i));
             Time time = parseTime(times.get(i));
-            result.add(new LessonSlot(subject, day, time));
+            lessonSlots.add(new LessonSlot(subject, day, time));
         }
-        Set<LessonSlot> seen = new HashSet<>();
-        Map<String, LessonSlot> byDayTime = new HashMap<>();
-        for (LessonSlot slot : result) {
-            if (!seen.add(slot)) {
+        Set<LessonSlot> seenLessonSlots = new HashSet<>();
+        Map<String, LessonSlot> slotsByDayTime = new HashMap<>();
+        for (LessonSlot slot : lessonSlots) {
+            if (!seenLessonSlots.add(slot)) {
                 throw new ParseException("Duplicate lesson slot: " + slot);
             }
             String key = slot.getDay() + "|" + slot.getTime();
-            LessonSlot existing = byDayTime.putIfAbsent(key, slot);
-            if (existing != null) {
+            LessonSlot conflictingSlot = slotsByDayTime.putIfAbsent(key, slot);
+            if (conflictingSlot != null) {
                 throw new ParseException("Overlapping lesson slots at "
-                        + existing.getDay() + " " + existing.getTime()
-                        + ": " + existing.getSubject()
+                        + conflictingSlot.getDay() + " " + conflictingSlot.getTime()
+                        + ": " + conflictingSlot.getSubject()
                         + " and " + slot.getSubject());
             }
         }
-        return result;
+        return lessonSlots;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,8 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -244,6 +246,21 @@ public class ParserUtil {
             Day day = parseDay(days.get(i));
             Time time = parseTime(times.get(i));
             result.add(new LessonSlot(subject, day, time));
+        }
+        Set<LessonSlot> seen = new HashSet<>();
+        Map<String, LessonSlot> byDayTime = new HashMap<>();
+        for (LessonSlot slot : result) {
+            if (!seen.add(slot)) {
+                throw new ParseException("Duplicate lesson slot: " + slot);
+            }
+            String key = slot.getDay() + "|" + slot.getTime();
+            LessonSlot existing = byDayTime.putIfAbsent(key, slot);
+            if (existing != null) {
+                throw new ParseException("Overlapping lesson slots at "
+                        + existing.getDay() + " " + existing.getTime()
+                        + ": " + existing.getSubject()
+                        + " and " + slot.getSubject());
+            }
         }
         return result;
     }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -65,10 +65,13 @@ public class PersonCard extends UiPart<Region> {
         remark.setText(remarkText.isEmpty() ? "" : "Remark: " + remarkText);
         remark.setVisible(!remarkText.isEmpty());
         remark.setManaged(!remarkText.isEmpty());
-        person.getLessonSlots().stream()
+        String lessonText = person.getLessonSlots().stream()
                 .sorted(Comparator.comparing(ls -> ls.toString()))
-                .forEach(ls -> lessonSlots.getChildren()
-                        .add(new Label(ls.toString())));
+                .map(ls -> ls.toString())
+                .collect(java.util.stream.Collectors.joining(", "));
+        if (!lessonText.isEmpty()) {
+            lessonSlots.getChildren().add(new Label(lessonText));
+        }
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren()

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="lessonSlots" hgap="5" vgap="3" />
+      <FlowPane fx:id="lessonSlots" />
       <FlowPane fx:id="tags" />
     </VBox>
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="lessonSlots" />
+      <FlowPane fx:id="lessonSlots" hgap="5" vgap="3" />
       <FlowPane fx:id="tags" />
     </VBox>
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.EmergencyContact;
+import seedu.address.model.person.LessonSlot;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.PaymentStatus;
 import seedu.address.model.person.Subject;
@@ -320,5 +322,45 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(
                 new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    // --- parseLessonSlots dedup & overlap detection ---
+
+    @Test
+    public void parseLessonSlots_exactDuplicate_throwsParseException() {
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseLessonSlots(
+                        Arrays.asList("Math", "Math"),
+                        Arrays.asList("Monday", "Monday"),
+                        Arrays.asList("1400", "1400")));
+    }
+
+    @Test
+    public void parseLessonSlots_overlappingDifferentSubject_throwsParseException() {
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseLessonSlots(
+                        Arrays.asList("Math", "English"),
+                        Arrays.asList("Friday", "Friday"),
+                        Arrays.asList("1400", "1400")));
+    }
+
+    @Test
+    public void parseLessonSlots_sameSubjectDifferentDays_success()
+            throws ParseException {
+        List<LessonSlot> slots = ParserUtil.parseLessonSlots(
+                Arrays.asList("Math", "Math"),
+                Arrays.asList("Monday", "Wednesday"),
+                Arrays.asList("1400", "1600"));
+        assertEquals(2, slots.size());
+    }
+
+    @Test
+    public void parseLessonSlots_sameDayDifferentTimes_success()
+            throws ParseException {
+        List<LessonSlot> slots = ParserUtil.parseLessonSlots(
+                Arrays.asList("Math", "English"),
+                Arrays.asList("Friday", "Friday"),
+                Arrays.asList("1400", "1600"));
+        assertEquals(2, slots.size());
     }
 }


### PR DESCRIPTION
## Summary
- Extend `ParserUtil.parseLessonSlots` to reject:
  - **Exact duplicates** (same subject+day+time) with "Duplicate lesson slot" error.
  - **Day+time overlaps** (different subjects at same day+time) with "Overlapping lesson slots" error.
- Both `add` and `edit` pass through this method — single fix covers all entry points.

## Test plan
- [x] `parseLessonSlots_exactDuplicate_throwsParseException`
- [x] `parseLessonSlots_overlappingDifferentSubject_throwsParseException`
- [x] `parseLessonSlots_sameSubjectDifferentDays_success` (no false positive)
- [x] `parseLessonSlots_sameDayDifferentTimes_success` (no false positive)
- [x] `./gradlew checkstyleMain checkstyleTest test` passes.
- [x] Manual verify: `add … s/Math d/Mon ti/1400 s/Math d/Mon ti/1400` → "Duplicate lesson slot"
- [x] Manual verify: `add … s/Math d/Fri ti/1400 s/English d/Fri ti/1400` → "Overlapping lesson slots"

Fixes #222, Fixes #236, Fixes #232, Fixes #256