### PR TITLE
Resolve view pop-up issue

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -464,27 +464,29 @@ Each `LessonSlot` currently stores only a start time. Adding a `Duration` field 
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
+Low-priority user stories may include future-facing features that are not implemented in the current version.
+Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enhancements).
+
 | Priority | As a …​                  | I want to …​                                           | So that I can…​                                              |
 |----------|--------------------------|---------------------------------------------------------|--------------------------------------------------------------|
 | `* * *`  | new user                 | see usage instructions                                  | refer to instructions when I forget how to use Tutor Central |
 | `* * *`  | tutor                    | add a student with schedule and payment details         | maintain complete student records                             |
-| `* * *`  | tutor                    | search for students                                     | find a target student quickly                                 |
-| `* * *`  | tutor                    | search students by subject, day, or payment status      | quickly find relevant students                                |
+| `* * *`  | tutor                    | list all students                                       | return to the full student list after searching or filtering |
+| `* * *`  | tutor                    | search for students by name                             | find a target student quickly                                 |
+| `* * *`  | tutor                    | search students by subject, day, payment status, or tag | quickly find relevant students                                |
 | `* * *`  | tutor                    | view a student's full details                           | check information before a lesson                             |
 | `* * *`  | tutor                    | delete a student                                        | remove entries that I no longer need                          |
+| `*`      | tutor                    | clear all student records                               | reset Tutor Central when starting over or switching datasets  |
 | `* *`    | tutor                    | update a student's details                              | correct outdated records when needed                          |
 | `* * *`  | tutor                    | mark a student's payment status                         | track who has paid without editing the full student record    |
 | `* * *`  | tutor                    | add a free-text remark to a student                     | record lesson notes, progress, or reminders quickly           |
-| `* *`    | tutor with many students | filter students by payment status                       | follow up with students who owe payment                       |
-| `* *`    | tutor                    | filter students by subject or day                       | plan my weekly schedule at a glance                           |
-| `* *`    | tutor                    | add remarks to a student                                | remember important notes about them                           |
-| `*`      | tutor                    | view a summary dialog of one student's full details     | quickly review all information before a lesson starts         |
 | `* * *`  | tutor                    | mark a student's attendance for a lesson                | keep accurate attendance records without paper                |
 | `* * *`  | tutor                    | view a student's attendance history                     | prepare for parent meetings with concrete data                |
-| `* * *`  | tutor                    | view a student's full details in one place              | check all information before a lesson without scrolling       |
+| `* * *`  | tutor                    | filter a student's attendance records by subject        | review one subject's attendance quickly                      |
 | `* * *`  | tutor                    | filter students by multiple criteria at once            | quickly find relevant students (e.g., Math on Monday)         |
-| `* *`    | tutor                    | update attendance if a student provides an MC later     | keep attendance records accurate even after the lesson        |
-| `* *`    | tutor                    | identify students who are frequently absent             | follow up with at-risk students and notify their parents      |
+| `* *`    | tutor                    | update a student's attendance after receiving new information | keep attendance records accurate even after the lesson        |
+| `* * *`  | tutor                    | have my student records saved automatically             | avoid losing updates between app sessions                     |
+| `*`      | tutor                    | identify students who are frequently absent             | follow up with at-risk students and notify their parents      |
 | `*`      | tutor                    | export student data                                     | share records with centre managers or parents                 |
 
 ### Use cases
@@ -1093,21 +1095,22 @@ Team size: 5
 
 2. **Improve error message when `markattendance` targets a non-existent lesson slot.** Currently the error says the student does not have the specified lesson slot, but does not list the valid slots. We will include the student's actual lesson slots in the error message (e.g., "Valid slots: Mathematics Monday 1400, English Wednesday 1000").
 
-3. **Add validation for duplicate lesson slots within a single student.** Currently, `add` and `edit` allow the same subject-day-time triplet to be specified twice. We will reject commands that contain duplicate lesson slot triplets and display an error message.
+3. **Standardise `listattendance` output when no records exist.** Currently, the message varies slightly depending on whether a subject filter was used. We will unify the output to always say "No attendance records found for [NAME]" optionally followed by "for subject [SUBJECT]".
 
-4. **Standardise `listattendance` output when no records exist.** Currently, the message varies slightly depending on whether a subject filter was used. We will unify the output to always say "No attendance records found for [NAME]" optionally followed by "for subject [SUBJECT]".
+4. **Make attendance pruning after `edit` more visible to users.** Currently, when a student's lesson slots are changed via `edit`, attendance records for removed slots are automatically pruned so stored attendance stays aligned with the current lesson schedule.
 
-5. **Make attendance pruning after `edit` more visible to users.** Currently, when a student's lesson slots are changed via `edit`, attendance records for removed slots are automatically pruned so stored attendance stays aligned with the current lesson schedule.
+5. **Make `view` dialog update when the underlying student data changes.** Currently, the `PersonViewDialog` shows a snapshot of the student at the time of the `view` command. If the user edits the student while the dialog is open, the dialog is not updated. We will bind the dialog to the model so it reflects live data.
 
-6. **Make `view` dialog update when the underlying student data changes.** Currently, the `PersonViewDialog` shows a snapshot of the student at the time of the `view` command. If the user edits the student while the dialog is open, the dialog is not updated. We will bind the dialog to the model so it reflects live data.
+6. **Add case-insensitive name matching for duplicate detection.** Currently, "alice tan" and "Alice Tan" are treated as different students. We will make `isSamePerson` case-insensitive so that names differing only by case are detected as duplicates.
 
-7. **Add case-insensitive name matching for duplicate detection.** Currently, "alice tan" and "Alice Tan" are treated as different students. We will make `isSamePerson` case-insensitive so that names differing only by case are detected as duplicates.
+7. **Clarify abbreviated day matching in `find`.** Currently, abbreviated day inputs such as `find d/Mon` are already accepted and normalized to `Monday`. We plan to improve the documentation and examples so this behavior is clearer to users.
 
-8. **Clarify abbreviated day matching in `find`.** Currently, abbreviated day inputs such as `find d/Mon` are already accepted and normalized to `Monday`. We plan to improve the documentation and examples so this behavior is clearer to users.
+8. **Add confirmation prompt for `clear` command.** Currently, `clear` deletes all students immediately with no confirmation. We will add a confirmation step (e.g., requiring `clear --confirm`) to prevent accidental data loss.
 
-9. **Add confirmation prompt for `clear` command.** Currently, `clear` deletes all students immediately with no confirmation. We will add a confirmation step (e.g., requiring `clear --confirm`) to prevent accidental data loss.
+9. **Allow `edit` with no changed values to succeed as a no-op.** Currently, running `edit 1` with no fields is rejected with an error ("At least one field to edit must be provided"). A future enhancement could detect when all supplied values are identical to the existing record and treat the command as a silent no-op success, which may feel more natural to users.
 
-10. **Allow `edit` with no changed values to succeed as a no-op.** Currently, running `edit 1` with no fields is rejected with an error ("At least one field to edit must be provided"). A future enhancement could detect when all supplied values are identical to the existing record and treat the command as a silent no-op success, which may feel more natural to users.
+10. **Relax name and subject validation to accept common special characters.** Currently, names and subjects only allow alphanumeric characters and spaces. This rejects real-world names containing hyphens (e.g., `Mary-Jane`), apostrophes (e.g., `O'Brien`), periods (e.g., `Dr. Smith`), or slashes (e.g., `s/o Kumar`), and subjects like `A-Math` or `Mother Tongue (Chinese)`. We will update the validation regex for both `Name` and `Subject` to accept hyphens, apostrophes, periods, parentheses, and slashes, while ensuring the slash character does not conflict with command prefix parsing.
 
-11. **Relax name and subject validation to accept common special characters.** Currently, names and subjects only allow alphanumeric characters and spaces. This rejects real-world names containing hyphens (e.g., `Mary-Jane`), apostrophes (e.g., `O'Brien`), periods (e.g., `Dr. Smith`), or slashes (e.g., `s/o Kumar`), and subjects like `A-Math` or `Mother Tongue (Chinese)`. We will update the validation regex for both `Name` and `Subject` to accept hyphens, apostrophes, periods, parentheses, and slashes, while ensuring the slash character does not conflict with command prefix parsing.
+11. **Identify students who are frequently absent.** Currently, tutors can view attendance history manually, but Tutor Central does not automatically flag students with repeated absences. We will add a way to identify students who are frequently absent so tutors can follow up with at-risk students and notify their parents.
 
+12. **Export student data.** Currently, student records can only be viewed inside Tutor Central or through the local JSON data file. We will add an export feature so tutors can share selected records with centre managers or parents in a more readable format.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -782,7 +782,6 @@ Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enh
 * **Student**: A learner whose information is managed in Tutor Central
 * **Subject**: An academic subject a student is enrolled in (e.g., Mathematics, English)
 * **Lesson Slot**: A scheduled lesson defined by a Subject, Day, and Time triplet (e.g., Mathematics on Monday at 1400)
-* **Lesson**: A specific class session within a subject
 * **Attendance**: The record of a student's presence at a lesson slot
 * **Attendance Status**: The recorded status for attendance: `Present`, `Absent`, or `Excused`
 * **Payment Status**: The financial status of a student: `Paid`, `Due`, or `Overdue`
@@ -790,10 +789,7 @@ Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enh
 * **Remark**: A free-text note attached to a student record
 * **Tag**: A label for categorizing students (e.g., `primary`, `priority`)
 * **Field**: A piece of data within a student record (e.g., Name, Emergency Contact)
-* **Timeslot**: The scheduled day and time of the tuition for a student
-* **Rate**: Tuition fee that is agreed upon
-* **Private student detail**: A student detail that is not meant to be shared with others
-* **Duplicate Record**: A new student entry that is identical or near identical to an existing entry
+* **Time-slot key**: The combined day and time string used to identify an attendance record (e.g., `Monday 1400`)
 
 #### Application Logic & Architecture
 
@@ -802,6 +798,7 @@ Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enh
 * **Storage**: The component that reads and writes data to JSON files
 * **Command**: A parsed user instruction ready for execution
 * **Predicate**: A filter condition applied to the student list
+* **Filtered list**: The currently displayed subset of students, usually produced by commands such as `find`; index-based commands operate on this list
 * **JSON**: The file format used for persistent data storage
 * **Auto-save**: Automatic saving of changes without needing any extra user action
 
@@ -811,7 +808,6 @@ Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enh
 * **Index**: The 1-based position number of a student in the displayed list
 * **Preamble**: Text before the first prefix in a command string
 * **Parameter**: A value provided to a command via a prefix
-* **Line-break**: In multi-line commands, it is the point where the command visually wraps to the next line in the display
 
 #### Interface & Environment
 
@@ -819,10 +815,10 @@ Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enh
 * **GUI**: Graphical User Interface, the visual display
 * **JavaFX**: The UI framework used by Tutor Central
 * **MarkBind**: The documentation framework used for the project website
-* **List View**: The graphical display showing all student records in a scrollable table or grid format
+* **List View**: The graphical display showing student records as a scrollable list
 * **Command Box**: The text box where users type commands
 * **Command Output Area**: The display area showing the results of commands entered (successes or failures)
-* **Mainstream OS**: Windows, Linux, Unix, MacOS
+* **Mainstream OS**: Windows, Linux, and macOS
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -121,13 +121,13 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 | `e/`   | Email             | Valid email format (e.g., `user@example.com`)                            |
 | `a/`   | Address           | Any text, cannot be blank                                                |
 | `ec/`  | Emergency Contact | Exactly 8 digits, must start with 8 or 9 (valid Singapore mobile number) |
-| `s/`   | Subject           | Alphanumeric characters and spaces; must not be blank                    |
+| `s/`   | Subject           | Alphanumeric characters and spaces; must not be blank; matching is case-insensitive |
 | `d/`   | Day               | Monday-Sunday (or Mon-Sun), case-insensitive                             |
 | `ti/`  | Time              | 4-digit 24-hour format, 0000-2359                                        |
-| `ps/`  | Payment Status    | One of: `Paid`, `Due`, `Overdue`                                         |
+| `ps/`  | Payment Status    | One of: `Paid`, `Due`, `Overdue`; case-insensitive                       |
 | `t/`   | Tag               | Alphanumeric characters, no spaces                                       |
 | `r/`   | Remark            | Any text (free-form)                                                     |
-| `st/`  | Attendance Status | One of: `Present`, `Absent`, `Excused`                                   |
+| `st/`  | Attendance Status | One of: `Present`, `Absent`, `Excused`; case-insensitive                 |
 
 **Important:** Subjects, days, and times must be specified in matching triplets. Each subject requires a corresponding day and time. If you provide 2 subjects, you must provide exactly 2 days and 2 times.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -299,6 +299,7 @@ Format: `markattendance INDEX s/SUBJECT d/DAY ti/TIME st/STATUS`
 - The index refers to the index number shown in the displayed student list.
 - The index **must be a positive integer** 1, 2, 3, ...
 - The student must have a lesson slot matching the specified subject, day, and time combination. Subject matching is case-insensitive.
+- Valid attendance statuses are `Present`, `Absent`, and `Excused`.
 - If an attendance record already exists for that subject and time slot, it is updated.
 - If no record exists, a new one is created.
 

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
+import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -65,6 +66,19 @@ public class ViewCommandTest {
     }
 
     @Test
+    public void execute_afterLessonSlotEdits_returnsPersonToView() throws Exception {
+        executeCommand("edit 2 s/chemistry d/tue ti/0900 s/chemistry d/fri ti/1400");
+        executeCommand("edit 3 s/chemistry d/fri ti/0900 s/Chemistry d/fri ti/1400");
+        executeCommand("edit 2 s/chemistry d/fri ti/0900 s/Chemistry d/fri ti/1400");
+
+        CommandResult result = executeCommand("view 2");
+        Person expectedPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        assertTrue(result.isShowView());
+        assertEquals(expectedPerson, result.getPersonToView());
+    }
+
+    @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
@@ -99,5 +113,9 @@ public class ViewCommandTest {
         ViewCommand viewCommand = new ViewCommand(targetIndex);
         String expected = ViewCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
         assertEquals(expected, viewCommand.toString());
+    }
+
+    private CommandResult executeCommand(String commandText) throws Exception {
+        return new AddressBookParser().parseCommand(commandText).execute(model);
     }
 }


### PR DESCRIPTION
Fixes #245 

Adds regression coverage for bug #245, where `view 2` was reported to not open after a sequence of lesson-slot edits.

The current codebase no longer reproduces the issue, but this test preserves the reported scenario to guard against regressions.

Tasks:
- Added a `ViewCommandTest` case using the exact reported edit sequence
- Verified that `view 2` returns a `CommandResult` with `isShowView() == true`
- Verified that the returned view target is the expected edited student

Manual verification:
- Ran the reported edit sequence in the GUI
- Confirmed that `view 2` opens the student details popup successfully