### PR TITLE
Fix tag parameter constraints in UG/DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -787,7 +787,7 @@ Such items are tracked in [Appendix: Planned Enhancements](#appendix-planned-enh
 * **Payment Status**: The financial status of a student: `Paid`, `Due`, or `Overdue`
 * **Emergency Contact**: An 8-digit Singapore phone number for a student's parent/guardian
 * **Remark**: A free-text note attached to a student record
-* **Tag**: A label for categorizing students (e.g., `primary`, `priority`)
+* **Tag**: A single-token label for categorizing students (e.g., `primary`, `exam-prep`, `lower_sec`)
 * **Field**: A piece of data within a student record (e.g., Name, Emergency Contact)
 * **Time-slot key**: The combined day and time string used to identify an attendance record (e.g., `Monday 1400`)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,7 +42,7 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 | **Payment Status**    | One of: `Paid`, `Due`, or `Overdue` — indicates the current fee payment status of a student                             |
 | **Subject**           | An academic subject a student is enrolled in (e.g., `Mathematics`, `English`)                                           |
 | **Lesson Slot**       | A scheduled tutoring session defined by a subject, day, and time (e.g., Mathematics on Monday at 1400)                  |
-| **Tag**               | A short alphanumeric label attached to a student for categorisation (e.g., `priority`, `trial`)                         |
+| **Tag**               | A short single-token label attached to a student for categorisation (e.g., `priority`, `exam-prep`, `lower_sec`)         |
 | **Remark**            | A free-text note attached to a student for any additional information                                                   |
 
 <!-- * Table of Contents -->
@@ -125,7 +125,7 @@ TutorCentral is a **desktop app for freelance tutors in Singapore** to manage st
 | `d/`   | Day               | Monday-Sunday (or Mon-Sun), case-insensitive                             |
 | `ti/`  | Time              | 4-digit 24-hour format, 0000-2359                                        |
 | `ps/`  | Payment Status    | One of: `Paid`, `Due`, `Overdue`; case-insensitive                       |
-| `t/`   | Tag               | Alphanumeric characters, no spaces                                       |
+| `t/`   | Tag               | Starts with an alphanumeric character; may contain alphanumeric characters, hyphens, and underscores; leading/trailing spaces are ignored; spaces inside tag names are not allowed |
 | `r/`   | Remark            | Any text (free-form)                                                     |
 | `st/`  | Attendance Status | One of: `Present`, `Absent`, `Excused`; case-insensitive                 |
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should start with an alphanumeric character "
+            + "and contain only alphanumeric characters, hyphens, and underscores";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum}_-]*";
 
     public final String tagName;
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -42,6 +42,7 @@ public class ParserUtilTest {
     private static final String VALID_SUBJECT_2 = "English";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_TAG_WITH_SYMBOLS = "exam-prep_2026";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -282,6 +283,13 @@ public class ParserUtilTest {
             throws Exception {
         Tag expectedTag = new Tag(VALID_TAG_1);
         assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_1));
+    }
+
+    @Test
+    public void parseTag_validValueWithAllowedSymbols_returnsTag()
+            throws Exception {
+        Tag expectedTag = new Tag(VALID_TAG_WITH_SYMBOLS);
+        assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_WITH_SYMBOLS));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -29,12 +29,16 @@ public class TagTest {
         // invalid tag names
         assertFalse(Tag.isValidTagName(""));
         assertFalse(Tag.isValidTagName("hello world")); // spaces not allowed
-        assertFalse(Tag.isValidTagName("tag-name")); // hyphens not allowed
+        assertFalse(Tag.isValidTagName("-tag")); // leading hyphen not allowed
+        assertFalse(Tag.isValidTagName("_tag")); // leading underscore not allowed
 
         // valid tag names
         assertTrue(Tag.isValidTagName("friend"));
         assertTrue(Tag.isValidTagName("123"));
         assertTrue(Tag.isValidTagName("friend123"));
+        assertTrue(Tag.isValidTagName("exam-prep"));
+        assertTrue(Tag.isValidTagName("lower_sec"));
+        assertTrue(Tag.isValidTagName("p1-math_2026"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #244 

Added that leading/trailing spaces are ignored in tag.

Also allowed hyphens and underscores in tag for better functionality.