### PR TITLE
Increase rows shown by listattendance

### DIFF
--- a/src/main/resources/view/PersonViewDialog.fxml
+++ b/src/main/resources/view/PersonViewDialog.fxml
@@ -69,7 +69,7 @@
                 <Font name="System Bold" size="13.0" />
             </font>
         </Label>
-        <ScrollPane fitToWidth="true" prefHeight="120.0" maxHeight="120.0">
+        <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="200.0" maxHeight="200.0">
             <VBox fx:id="attendanceRecordsBox" spacing="3.0">
                 <padding>
                     <Insets left="5.0" />


### PR DESCRIPTION
### Summary

- Fixes #269
- Increase number of rows displayed by the listattendance command
- Vertical scroll only when lesson records exceeds 8