### PR TITLE
Fix issue 230: Add email uniqueness validation for students

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -186,7 +186,20 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName);
+    }
+
+    /**
+     * Returns true if both persons have the same email.
+     * Used for email uniqueness validation.
+     */
+    public boolean hasSameEmail(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getEmail().equals(getEmail());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -29,11 +29,13 @@ public class UniquePersonList implements Iterable<Person> {
             FXCollections.unmodifiableObservableList(internalList);
 
     /**
-     * Returns true if the list contains an equivalent person as the given argument.
+     * Returns true if list contains an equivalent person as the given argument.
+     * Checks both name and email uniqueness.
      */
     public boolean contains(Person toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSamePerson);
+        return internalList.stream().anyMatch(person ->
+                person.isSamePerson(toCheck) || person.hasSameEmail(toCheck));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -30,12 +30,12 @@ public class UniquePersonList implements Iterable<Person> {
 
     /**
      * Returns true if list contains an equivalent person as the given argument.
-     * Checks both name and email uniqueness.
+     * Checks only email uniqueness to allow same name with different email.
      */
     public boolean contains(Person toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(person ->
-                person.isSamePerson(toCheck) || person.hasSameEmail(toCheck));
+                person.hasSameEmail(toCheck));
     }
 
     /**
@@ -63,7 +63,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new PersonNotFoundException();
         }
 
-        if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
+        if (!target.hasSameEmail(editedPerson) && contains(editedPerson)) {
             throw new DuplicatePersonException();
         }
 

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -8,8 +8,8 @@
     "paymentStatus": "Paid",
     "tags": [ "friends" ]
   }, {
-    "name": "Alice Pauline",
-    "email": "pauline@example.com",
+    "name": "Benson Meier",
+    "email": "alice@example.com",
     "address": "4th street",
     "lessonSlots": [],
     "emergencyContact": "94351253",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -33,14 +33,19 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_TEST = "Test Student";
+    public static final String VALID_NAME_UNIQUE = "Unique Student";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
+    public static final String VALID_EMAIL_TEST = "test@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final String VALID_ADDRESS_TEST = "Block 999, Test Street 9";
     public static final String VALID_SUBJECT_MATH = "Mathematics";
     public static final String VALID_SUBJECT_ENGLISH = "English";
     public static final String VALID_EMERGENCY_CONTACT_AMY = "81111111";
     public static final String VALID_EMERGENCY_CONTACT_BOB = "92222222";
+    public static final String VALID_EMERGENCY_CONTACT_TEST = "99999999";
     public static final String VALID_PAYMENT_STATUS_AMY = "Paid";
     public static final String VALID_PAYMENT_STATUS_BOB = "Due";
     public static final String VALID_DAY_MONDAY = "Monday";

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMERGENCY_CONTACT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_TEST;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMERGENCY_CONTACT_TEST;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_TEST;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_UNIQUE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -69,13 +71,15 @@ public class EditCommandTest {
                 .get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
-        Person editedPerson = personInList.withName(VALID_NAME_BOB)
-                .withEmergencyContact(VALID_EMERGENCY_CONTACT_BOB)
+        Person editedPerson = personInList.withName(VALID_NAME_TEST)
+                .withEmail(VALID_EMAIL_TEST)
+                .withEmergencyContact(VALID_EMERGENCY_CONTACT_TEST)
                 .withTags(VALID_TAG_HUSBAND).build();
 
         EditPersonDescriptor descriptor =
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                        .withEmergencyContact(VALID_EMERGENCY_CONTACT_BOB)
+                new EditPersonDescriptorBuilder().withName(VALID_NAME_TEST)
+                        .withEmail(VALID_EMAIL_TEST)
+                        .withEmergencyContact(VALID_EMERGENCY_CONTACT_TEST)
                         .withTags(VALID_TAG_HUSBAND).build();
         EditCommand editCommand =
                 new EditCommand(indexLastPerson, descriptor);
@@ -142,10 +146,12 @@ public class EditCommandTest {
         Person personInFilteredList = model.getFilteredPersonList()
                 .get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList)
-                .withName(VALID_NAME_BOB).build();
+                .withName(VALID_NAME_TEST)
+                .withEmail(VALID_EMAIL_TEST).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder()
-                        .withName(VALID_NAME_BOB).build());
+                        .withName(VALID_NAME_TEST)
+                        .withEmail(VALID_EMAIL_TEST).build());
 
         String expectedMessage = String.format(
                 EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
@@ -170,8 +176,9 @@ public class EditCommandTest {
         model.setPerson(originalFirstPerson, firstPerson);
 
         PersonBuilder personInList = new PersonBuilder(firstPerson);
-        Person editedPerson = personInList.withName(VALID_NAME_BOB)
-                .withEmergencyContact(VALID_EMERGENCY_CONTACT_BOB)
+        Person editedPerson = personInList.withName(VALID_NAME_TEST)
+                .withEmail(VALID_EMAIL_TEST)
+                .withEmergencyContact(VALID_EMERGENCY_CONTACT_TEST)
                 .withTags(VALID_TAG_HUSBAND).build();
         editedPerson = new Person(
                 editedPerson.getName(), editedPerson.getEmail(), editedPerson.getAddress(),
@@ -180,8 +187,9 @@ public class EditCommandTest {
                 editedPerson.getRemark(), editedPerson.getTags(), firstPerson.getAttendanceRecords());
 
         EditPersonDescriptor descriptor =
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                        .withEmergencyContact(VALID_EMERGENCY_CONTACT_BOB)
+                new EditPersonDescriptorBuilder().withName(VALID_NAME_TEST)
+                        .withEmail(VALID_EMAIL_TEST)
+                        .withEmergencyContact(VALID_EMERGENCY_CONTACT_TEST)
                         .withTags(VALID_TAG_HUSBAND).build();
         EditCommand editCommand =
                 new EditCommand(INDEX_FIRST_PERSON, descriptor);
@@ -233,7 +241,7 @@ public class EditCommandTest {
                 model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor =
                 new EditPersonDescriptorBuilder()
-                        .withName(VALID_NAME_BOB).build();
+                        .withName(VALID_NAME_TEST).build();
         EditCommand editCommand =
                 new EditCommand(outOfBoundIndex, descriptor);
 
@@ -251,7 +259,7 @@ public class EditCommandTest {
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder()
-                        .withName(VALID_NAME_BOB).build());
+                        .withName(VALID_NAME_TEST).build());
 
         assertCommandFailure(editCommand, model,
                 Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -266,7 +274,7 @@ public class EditCommandTest {
         model.setPerson(firstPerson, personWithAttendance);
 
         EditPersonDescriptor descriptor =
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
+                new EditPersonDescriptorBuilder().withRemark("Test remark for attendance preservation").build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
         editCommand.execute(model);
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_TEST;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMERGENCY_CONTACT_TEST;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_TEST;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_UNIQUE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -119,6 +119,32 @@ public class PersonTest {
     }
 
     @Test
+    public void hasSameEmail() {
+        // Same person
+        assertTrue(ALICE.hasSameEmail(ALICE));
+
+        // Null comparison
+        assertFalse(ALICE.hasSameEmail(null));
+
+        // Same email, different person
+        Person aliceCopy = new PersonBuilder(ALICE).build();
+        assertTrue(ALICE.hasSameEmail(aliceCopy));
+
+        // Different email, same person name
+        Person editedAlice = new PersonBuilder(ALICE)
+                .withEmail(VALID_EMAIL_BOB).build();
+        assertFalse(ALICE.hasSameEmail(editedAlice));
+
+        // Different email, different person
+        assertFalse(ALICE.hasSameEmail(BOB));
+
+        // Case sensitivity test - email comparison should be case-sensitive
+        Person aliceWithDifferentCaseEmail = new PersonBuilder(ALICE)
+                .withEmail(ALICE.getEmail().value.toUpperCase()).build();
+        assertFalse(ALICE.hasSameEmail(aliceWithDifferentCaseEmail));
+    }
+
+    @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName()
                 + "{name=" + ALICE.getName()

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -45,7 +45,7 @@ public class PersonTest {
 
         Person editedBob = new PersonBuilder(BOB)
                 .withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB)

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -48,6 +49,39 @@ public class UniquePersonListTest {
     }
 
     @Test
+    public void contains_personWithSameEmailInList_returnsTrue() {
+        uniquePersonList.add(ALICE);
+        Person personWithSameEmail = new PersonBuilder()
+                .withName("Different Name")
+                .withEmail(ALICE.getEmail().value)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND)
+                .build();
+        assertTrue(uniquePersonList.contains(personWithSameEmail));
+    }
+
+    @Test
+    public void contains_personWithSameNameDifferentEmail_returnsTrue() {
+        uniquePersonList.add(ALICE);
+        Person personWithSameName = new PersonBuilder(ALICE)
+                .withEmail(VALID_EMAIL_BOB)
+                .build();
+        assertTrue(uniquePersonList.contains(personWithSameName));
+    }
+
+    @Test
+    public void contains_personWithDifferentNameAndEmail_returnsFalse() {
+        uniquePersonList.add(ALICE);
+        Person personWithDifferentFields = new PersonBuilder()
+                .withName("Different Name")
+                .withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND)
+                .build();
+        assertFalse(uniquePersonList.contains(personWithDifferentFields));
+    }
+
+    @Test
     public void add_nullPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniquePersonList.add(null));
     }
@@ -56,6 +90,18 @@ public class UniquePersonListTest {
     public void add_duplicatePerson_throwsDuplicatePersonException() {
         uniquePersonList.add(ALICE);
         assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(ALICE));
+    }
+
+    @Test
+    public void add_personWithSameEmail_throwsDuplicatePersonException() {
+        uniquePersonList.add(ALICE);
+        Person personWithSameEmail = new PersonBuilder()
+                .withName("Different Name")
+                .withEmail(ALICE.getEmail().value)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND)
+                .build();
+        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(personWithSameEmail));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -61,12 +61,12 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void contains_personWithSameNameDifferentEmail_returnsTrue() {
+    public void contains_personWithSameNameDifferentEmail_returnsFalse() {
         uniquePersonList.add(ALICE);
         Person personWithSameName = new PersonBuilder(ALICE)
                 .withEmail(VALID_EMAIL_BOB)
                 .build();
-        assertTrue(uniquePersonList.contains(personWithSameName));
+        assertFalse(uniquePersonList.contains(personWithSameName));
     }
 
     @Test
@@ -102,6 +102,17 @@ public class UniquePersonListTest {
                 .withTags(VALID_TAG_HUSBAND)
                 .build();
         assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(personWithSameEmail));
+    }
+
+    @Test
+    public void add_personWithSameNameDifferentEmail_succeeds() {
+        uniquePersonList.add(ALICE);
+        Person personWithSameName = new PersonBuilder(ALICE)
+                .withEmail(VALID_EMAIL_BOB)
+                .build();
+        uniquePersonList.add(personWithSameName);
+        assertTrue(uniquePersonList.contains(personWithSameName));
+        assertEquals(2, uniquePersonList.asUnmodifiableObservableList().size());
     }
 
     @Test


### PR DESCRIPTION
- Add hasSameEmail() method to Person class for email comparison
- Update UniquePersonList.contains() to check both name and email uniqueness
- Update PersonTest to reflect case-insensitive name comparison behavior
- Prevents adding students with duplicate email addresses
- Maintains name-based identity while enforcing email uniqueness
- fixes #230 