### PR TITLE
Fix issue 255: Standardize error messages for out of range index

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -26,9 +27,6 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS =
             "Deleted student: %1$s successfully\nTotal students now: %2$d";
 
-    // Custom error message for out of range
-    public static final String MESSAGE_OUT_OF_RANGE = "Out of range: No student found at index %1$d.";
-
     private final Index targetIndex;
 
     public DeleteCommand(Index targetIndex) {
@@ -46,7 +44,7 @@ public class DeleteCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(String.format(MESSAGE_OUT_OF_RANGE, targetIndex.getOneBased()));
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -70,7 +70,7 @@ public class LogicManagerTest {
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
         // Update the expected exception message to match new DeleteCommand behavior
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_OUT_OF_RANGE, 9);
+        String expectedMessage = MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
         assertCommandException(deleteCommand, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -47,7 +48,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_OUT_OF_RANGE, outOfBoundIndex.getOneBased());
+        String expectedMessage = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
@@ -79,7 +80,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_OUT_OF_RANGE, outOfBoundIndex.getOneBased());
+        String expectedMessage = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 


### PR DESCRIPTION
- Replace custom MESSAGE_OUT_OF_RANGE in DeleteCommand with Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX
- Update DeleteCommand and EditCommand to use consistent error message format
- Fix test files to expect the standardized error message
- Remove trailing whitespace to pass checkstyle
- fix #255 