### PR TITLE
feat: add AttendanceRecordKey infrastructure for lesson-based attendance (#251)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -31,6 +31,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.AttendanceRecordKey;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.LessonSlot;
@@ -177,7 +178,11 @@ public class EditCommand extends Command {
             }
 
             attendanceBySlot.forEach((attendanceKey, status) -> {
-                String canonicalSubject = allowedAttendanceKeys.get(attendanceKey);
+                String slotKey = AttendanceRecordKey.getLessonSlotKey(attendanceKey);
+                String canonicalSubject = allowedAttendanceKeys.get(slotKey);
+                if (canonicalSubject == null) {
+                    return;
+                }
                 prunedRecords.computeIfAbsent(canonicalSubject, key -> new LinkedHashMap<>())
                         .put(attendanceKey, status);
             });

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.AttendanceStatus;
 import seedu.address.model.person.Day;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.EmergencyContact;
+import seedu.address.model.person.Lesson;
 import seedu.address.model.person.LessonSlot;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.PaymentStatus;
@@ -263,6 +264,21 @@ public class ParserUtil {
             }
         }
         return lessonSlots;
+    }
+
+    /**
+     * Parses a {@code String lessonName} into a valid lesson/session label.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code lessonName} is invalid.
+     */
+    public static String parseLessonName(String lessonName) throws ParseException {
+        requireNonNull(lessonName);
+        String trimmed = lessonName.trim();
+        if (!Lesson.isValidLessonName(trimmed)) {
+            throw new ParseException(Lesson.MESSAGE_CONSTRAINTS);
+        }
+        return trimmed;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/AttendanceRecordKey.java
+++ b/src/main/java/seedu/address/model/person/AttendanceRecordKey.java
@@ -1,0 +1,51 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utility methods for attendance record keys.
+ * A record key uses the format "Day Time - Lesson",
+ * e.g. "Monday 1400 - 2026-04-13 Algebra Lesson 2".
+ */
+public final class AttendanceRecordKey {
+
+    private AttendanceRecordKey() {}
+
+    /**
+     * Creates an attendance record key from the given day, time, and lesson label.
+     */
+    public static String of(String day, String time, String lesson) {
+        requireNonNull(day);
+        requireNonNull(time);
+        requireNonNull(lesson);
+        return day + " " + time + " - " + lesson;
+    }
+
+    /**
+     * Extracts the lesson slot key ("Day Time") from a full attendance record key.
+     */
+    public static String getLessonSlotKey(String recordKey) {
+        requireNonNull(recordKey);
+        int idx = recordKey.indexOf(" - ");
+        return idx == -1 ? "" : recordKey.substring(0, idx);
+    }
+
+    /**
+     * Returns true if the given string is a valid attendance record key.
+     */
+    public static boolean isValid(String recordKey) {
+        requireNonNull(recordKey);
+        int idx = recordKey.indexOf(" - ");
+        if (idx == -1) {
+            return false;
+        }
+        String slotKey = recordKey.substring(0, idx);
+        String[] parts = slotKey.split(" ");
+        if (parts.length != 2 || !Day.isValidDay(parts[0])
+                || !Time.isValidTime(parts[1])) {
+            return false;
+        }
+        String lesson = recordKey.substring(idx + 3);
+        return !lesson.isEmpty() && Lesson.isValidLessonName(lesson);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Lesson.java
+++ b/src/main/java/seedu/address/model/person/Lesson.java
@@ -13,9 +13,9 @@ import java.util.Objects;
 public class Lesson {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Lesson names should only contain alphanumeric characters and spaces, and should not be blank";
+            "Lesson names should only contain alphanumeric characters, spaces, and hyphens, and should not be blank";
 
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} -]*";
 
     public final String lessonName;
     public final AttendanceStatus status;

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.AttendanceRecordKey;
 import seedu.address.model.person.AttendanceStatus;
-import seedu.address.model.person.Day;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.LessonSlot;
@@ -23,7 +23,6 @@ import seedu.address.model.person.PaymentStatus;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Remark;
 import seedu.address.model.person.Subject;
-import seedu.address.model.person.Time;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -33,7 +32,7 @@ class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
     public static final String INVALID_ATTENDANCE_KEY_FORMAT =
-            "Attendance key must be in 'Day Time' format (e.g., 'Monday 1400')";
+            "Attendance key must be in 'Day Time - Lesson' format";
 
     private final String name;
     private final String email;
@@ -189,7 +188,7 @@ class JsonAdaptedPerson {
             Map<String, AttendanceStatus> lessonMap = new LinkedHashMap<>();
             for (Map.Entry<String, String> lessonEntry : subjectEntry.getValue().entrySet()) {
                 String lessonKey = lessonEntry.getKey();
-                if (!isValidAttendanceKey(lessonKey)) {
+                if (!AttendanceRecordKey.isValid(lessonKey)) {
                     throw new IllegalValueException(INVALID_ATTENDANCE_KEY_FORMAT);
                 }
                 if (!AttendanceStatus.isValidStatus(lessonEntry.getValue())) {
@@ -205,17 +204,6 @@ class JsonAdaptedPerson {
                 modelLessonSlots,
                 modelEmergencyContact, modelPaymentStatus, modelRemark, modelTags,
                 modelAttendanceRecords);
-    }
-
-    /**
-     * Returns true if the attendance key is in valid "Day Time" format.
-     */
-    private static boolean isValidAttendanceKey(String key) {
-        String[] parts = key.split(" ");
-        if (parts.length != 2) {
-            return false;
-        }
-        return Day.isValidDay(parts[0]) && Time.isValidTime(parts[1]);
     }
 
 }

--- a/src/test/data/JsonAttendanceStorageTest/personWithInvalidAttendanceStatus.json
+++ b/src/test/data/JsonAttendanceStorageTest/personWithInvalidAttendanceStatus.json
@@ -8,7 +8,7 @@
     "paymentStatus": "Paid",
     "tags": [],
     "attendanceRecords": {
-      "Mathematics": { "Monday 1400": "InvalidStatus" }
+      "Mathematics": { "Monday 1400 - Lesson 1": "InvalidStatus" }
     }
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -311,6 +311,24 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_editLessonSlots_prunesNonMatchingSlotWithinSubject() throws Exception {
+        Person firstPerson = model.getFilteredPersonList().get(0);
+        Person personWithAttendance = firstPerson
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
+        model.setPerson(firstPerson, personWithAttendance);
+
+        // Keep Mathematics but change to a different day/time
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withLessonSlots("Mathematics", "Wednesday", "1600")
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        editCommand.execute(model);
+
+        Person edited = model.getFilteredPersonList().get(0);
+        assertTrue(edited.getAttendanceRecords().isEmpty());
+    }
+
+    @Test
     public void equals() {
         // Utility behavior: equality partitions for command identity
         final EditCommand standardCommand =

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -166,7 +166,7 @@ public class EditCommandTest {
         Person originalFirstPerson = model.getFilteredPersonList()
                 .get(INDEX_FIRST_PERSON.getZeroBased());
         Person firstPerson = originalFirstPerson.markAttendance(
-                "Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+                "Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         model.setPerson(originalFirstPerson, firstPerson);
 
         PersonBuilder personInList = new PersonBuilder(firstPerson);
@@ -261,7 +261,7 @@ public class EditCommandTest {
     public void execute_editNameOnly_preservesAttendanceRecords() throws Exception {
         Person firstPerson = model.getFilteredPersonList().get(0);
         Person personWithAttendance = firstPerson.markAttendance(
-                "Mathematics", "Monday 1400",
+                "Mathematics", "Monday 1400 - Lesson 1",
                 seedu.address.model.person.AttendanceStatus.PRESENT);
         model.setPerson(firstPerson, personWithAttendance);
 
@@ -279,7 +279,7 @@ public class EditCommandTest {
     public void execute_editLessonSlots_prunesRemovedAttendanceRecords() throws Exception {
         Person firstPerson = model.getFilteredPersonList().get(0);
         Person personWithAttendance = firstPerson
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         model.setPerson(firstPerson, personWithAttendance);
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
@@ -296,7 +296,7 @@ public class EditCommandTest {
     public void execute_editLessonSlots_keepsMatchingAttendanceRecords() throws Exception {
         Person firstPerson = model.getFilteredPersonList().get(0);
         Person personWithAttendance = firstPerson
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         model.setPerson(firstPerson, personWithAttendance);
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
@@ -307,7 +307,7 @@ public class EditCommandTest {
 
         Person edited = model.getFilteredPersonList().get(0);
         assertEquals(AttendanceStatus.PRESENT,
-                edited.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                edited.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -332,6 +332,24 @@ public class ParserUtilTest {
         assertEquals(expectedTagSet, actualTagSet);
     }
 
+    // --- parseLessonName ---
+
+    @Test
+    public void parseLessonName_validName_returnsName() throws Exception {
+        assertEquals("Lesson 1", ParserUtil.parseLessonName("Lesson 1"));
+        assertEquals("2026-04-13 Algebra", ParserUtil.parseLessonName("  2026-04-13 Algebra  "));
+    }
+
+    @Test
+    public void parseLessonName_invalidName_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLessonName("!invalid"));
+    }
+
+    @Test
+    public void parseLessonName_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseLessonName(null));
+    }
+
     // --- parseLessonSlots dedup & overlap detection ---
 
     @Test

--- a/src/test/java/seedu/address/model/person/AttendanceRecordKeyTest.java
+++ b/src/test/java/seedu/address/model/person/AttendanceRecordKeyTest.java
@@ -43,6 +43,11 @@ public class AttendanceRecordKeyTest {
     }
 
     @Test
+    public void isValid_missingTimePart_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("Monday - Lesson 1"));
+    }
+
+    @Test
     public void isValid_invalidDay_returnsFalse() {
         assertFalse(AttendanceRecordKey.isValid("Funday 1400 - Lesson 1"));
     }

--- a/src/test/java/seedu/address/model/person/AttendanceRecordKeyTest.java
+++ b/src/test/java/seedu/address/model/person/AttendanceRecordKeyTest.java
@@ -1,0 +1,65 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class AttendanceRecordKeyTest {
+
+    @Test
+    public void of_validInputs_returnsCorrectKey() {
+        assertEquals("Monday 1400 - 2026-04-13 Algebra Lesson 2",
+                AttendanceRecordKey.of("Monday", "1400", "2026-04-13 Algebra Lesson 2"));
+    }
+
+    @Test
+    public void getLessonSlotKey_validKey_returnsSlotPortion() {
+        assertEquals("Monday 1400",
+                AttendanceRecordKey.getLessonSlotKey("Monday 1400 - 2026-04-13 Algebra Lesson 2"));
+    }
+
+    @Test
+    public void getLessonSlotKey_noSeparator_returnsEmpty() {
+        assertEquals("", AttendanceRecordKey.getLessonSlotKey("Monday 1400"));
+    }
+
+    @Test
+    public void isValid_validKey_returnsTrue() {
+        assertTrue(AttendanceRecordKey.isValid("Monday 1400 - 2026-04-13 Algebra Lesson 2"));
+        assertTrue(AttendanceRecordKey.isValid("Friday 0900 - Lesson 1"));
+        assertTrue(AttendanceRecordKey.isValid("Wednesday 1600 - Week3"));
+    }
+
+    @Test
+    public void isValid_noSeparator_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("Monday 1400"));
+    }
+
+    @Test
+    public void isValid_emptyLesson_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("Monday 1400 - "));
+    }
+
+    @Test
+    public void isValid_invalidDay_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("Funday 1400 - Lesson 1"));
+    }
+
+    @Test
+    public void isValid_invalidTime_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("Monday 9999 - Lesson 1"));
+    }
+
+    @Test
+    public void isValid_malformedKey_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("!InvalidKey"));
+        assertFalse(AttendanceRecordKey.isValid(""));
+    }
+
+    @Test
+    public void isValid_invalidLessonName_returnsFalse() {
+        assertFalse(AttendanceRecordKey.isValid("Monday 1400 - !invalid"));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonAttendanceTest.java
+++ b/src/test/java/seedu/address/model/person/PersonAttendanceTest.java
@@ -26,7 +26,7 @@ public class PersonAttendanceTest {
     public void attendanceConstructor_copiesRecordsDefensively() {
         Map<String, Map<String, AttendanceStatus>> records = new LinkedHashMap<>();
         Map<String, AttendanceStatus> inner = new LinkedHashMap<>();
-        inner.put("Monday 1400", AttendanceStatus.PRESENT);
+        inner.put("Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         records.put("Mathematics", inner);
 
         Person person = new PersonBuilder().build();
@@ -37,14 +37,14 @@ public class PersonAttendanceTest {
                 person.getRemark(), person.getTags(), records);
 
         // Mutating original map should not affect person's records
-        inner.put("Tuesday 0900", AttendanceStatus.ABSENT);
+        inner.put("Tuesday 0900 - Lesson 2", AttendanceStatus.ABSENT);
         assertEquals(1, personWithRecords.getAttendanceRecords().get("Mathematics").size());
     }
 
     @Test
     public void getAttendanceRecords_returnsUnmodifiableView() {
         Person person = new PersonBuilder().build()
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         Map<String, Map<String, AttendanceStatus>> records = person.getAttendanceRecords();
         org.junit.jupiter.api.Assertions.assertThrows(UnsupportedOperationException.class, ()
                 -> records.put("Science", new LinkedHashMap<>()));
@@ -53,36 +53,37 @@ public class PersonAttendanceTest {
     @Test
     public void markAttendance_returnsNewPersonWithUpdatedRecord() {
         Person original = new PersonBuilder().build();
-        Person updated = original.markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+        Person updated = original.markAttendance(
+                "Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
 
         assertNotSame(original, updated);
         assertTrue(original.getAttendanceRecords().isEmpty());
         assertEquals(AttendanceStatus.PRESENT,
-                updated.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                updated.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
     }
 
     @Test
     public void markAttendance_multipleSubjectsAndLessons() {
         Person person = new PersonBuilder().build()
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT)
-                .markAttendance("Mathematics", "Wednesday 1600", AttendanceStatus.ABSENT)
-                .markAttendance("Science", "Friday 0900", AttendanceStatus.EXCUSED);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT)
+                .markAttendance("Mathematics", "Wednesday 1600 - Lesson 2", AttendanceStatus.ABSENT)
+                .markAttendance("Science", "Friday 0900 - Lesson 3", AttendanceStatus.EXCUSED);
 
         Map<String, Map<String, AttendanceStatus>> records = person.getAttendanceRecords();
         assertEquals(2, records.size());
-        assertEquals(AttendanceStatus.PRESENT, records.get("Mathematics").get("Monday 1400"));
-        assertEquals(AttendanceStatus.ABSENT, records.get("Mathematics").get("Wednesday 1600"));
-        assertEquals(AttendanceStatus.EXCUSED, records.get("Science").get("Friday 0900"));
+        assertEquals(AttendanceStatus.PRESENT, records.get("Mathematics").get("Monday 1400 - Lesson 1"));
+        assertEquals(AttendanceStatus.ABSENT, records.get("Mathematics").get("Wednesday 1600 - Lesson 2"));
+        assertEquals(AttendanceStatus.EXCUSED, records.get("Science").get("Friday 0900 - Lesson 3"));
     }
 
     @Test
     public void markAttendance_overwritesExistingRecord() {
         Person person = new PersonBuilder().build()
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.ABSENT)
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.ABSENT)
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
 
         assertEquals(AttendanceStatus.PRESENT,
-                person.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                person.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
     }
 
     @Test
@@ -112,18 +113,18 @@ public class PersonAttendanceTest {
     @Test
     public void equals_sameAttendanceRecords_areEqual() {
         Person p1 = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         Person p2 = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         assertEquals(p1, p2);
     }
 
     @Test
     public void equals_differentAttendanceRecords_areNotEqual() {
         Person p1 = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         Person p2 = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.ABSENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.ABSENT);
         assertNotEquals(p1, p2);
     }
 
@@ -131,16 +132,16 @@ public class PersonAttendanceTest {
     public void equals_emptyVsNonEmptyAttendance_areNotEqual() {
         Person empty = new PersonBuilder().build();
         Person withRecords = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         assertNotEquals(empty, withRecords);
     }
 
     @Test
     public void hashCode_sameAttendanceRecords_sameHash() {
         Person p1 = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         Person p2 = new PersonBuilder().build()
-                .markAttendance("Math", "Monday 1400", AttendanceStatus.PRESENT);
+                .markAttendance("Math", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         assertEquals(p1.hashCode(), p2.hashCode());
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -210,11 +210,11 @@ public class JsonAdaptedPersonTest {
     public void toModelType_validAttendanceRecords_roundTrip() throws Exception {
         Map<String, Map<String, String>> records = new LinkedHashMap<>();
         Map<String, String> mathLessons = new LinkedHashMap<>();
-        mathLessons.put("Monday 1400", "Present");
-        mathLessons.put("Wednesday 1600", "Absent");
+        mathLessons.put("Monday 1400 - Lesson 1", "Present");
+        mathLessons.put("Wednesday 1600 - Lesson 2", "Absent");
         records.put("Mathematics", mathLessons);
         Map<String, String> engLessons = new LinkedHashMap<>();
-        engLessons.put("Tuesday 0900", "Excused");
+        engLessons.put("Tuesday 0900 - Lesson 1", "Excused");
         records.put("English", engLessons);
 
         JsonAdaptedPerson adapted = new JsonAdaptedPerson(
@@ -225,34 +225,34 @@ public class JsonAdaptedPersonTest {
 
         Person modelPerson = adapted.toModelType();
         assertEquals(AttendanceStatus.PRESENT,
-                modelPerson.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                modelPerson.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
         assertEquals(AttendanceStatus.ABSENT,
-                modelPerson.getAttendanceRecords().get("Mathematics").get("Wednesday 1600"));
+                modelPerson.getAttendanceRecords().get("Mathematics").get("Wednesday 1600 - Lesson 2"));
         assertEquals(AttendanceStatus.EXCUSED,
-                modelPerson.getAttendanceRecords().get("English").get("Tuesday 0900"));
+                modelPerson.getAttendanceRecords().get("English").get("Tuesday 0900 - Lesson 1"));
     }
 
     @Test
     public void toModelType_attendanceRoundTripViaPersonConstructor() throws Exception {
         Person original = BENSON
-                .markAttendance("English", "Tuesday 0900", AttendanceStatus.PRESENT)
-                .markAttendance("English", "Thursday 1500", AttendanceStatus.ABSENT);
+                .markAttendance("English", "Tuesday 0900 - Lesson 1", AttendanceStatus.PRESENT)
+                .markAttendance("English", "Thursday 1500 - Lesson 2", AttendanceStatus.ABSENT);
 
         JsonAdaptedPerson adapted = new JsonAdaptedPerson(original);
         Person restored = adapted.toModelType();
 
         assertEquals(original, restored);
         assertEquals(AttendanceStatus.PRESENT,
-                restored.getAttendanceRecords().get("English").get("Tuesday 0900"));
+                restored.getAttendanceRecords().get("English").get("Tuesday 0900 - Lesson 1"));
         assertEquals(AttendanceStatus.ABSENT,
-                restored.getAttendanceRecords().get("English").get("Thursday 1500"));
+                restored.getAttendanceRecords().get("English").get("Thursday 1500 - Lesson 2"));
     }
 
     @Test
     public void toModelType_invalidAttendanceStatus_throwsIllegalValueException() {
         Map<String, Map<String, String>> invalidRecords = new LinkedHashMap<>();
         Map<String, String> lessons = new LinkedHashMap<>();
-        lessons.put("Monday 1400", "InvalidStatus");
+        lessons.put("Monday 1400 - Lesson 1", "InvalidStatus");
         invalidRecords.put("Mathematics", lessons);
 
         JsonAdaptedPerson person = new JsonAdaptedPerson(
@@ -268,8 +268,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_caseInsensitiveAttendanceStatus_normalises() throws Exception {
         Map<String, Map<String, String>> records = new LinkedHashMap<>();
         Map<String, String> lessons = new LinkedHashMap<>();
-        lessons.put("Monday 1400", "present");
-        lessons.put("Wednesday 1600", "ABSENT");
+        lessons.put("Monday 1400 - Lesson 1", "present");
+        lessons.put("Wednesday 1600 - Lesson 2", "ABSENT");
         records.put("Mathematics", lessons);
 
         JsonAdaptedPerson person = new JsonAdaptedPerson(
@@ -280,16 +280,16 @@ public class JsonAdaptedPersonTest {
 
         Person modelPerson = person.toModelType();
         assertEquals(AttendanceStatus.PRESENT,
-                modelPerson.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                modelPerson.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
         assertEquals(AttendanceStatus.ABSENT,
-                modelPerson.getAttendanceRecords().get("Mathematics").get("Wednesday 1600"));
+                modelPerson.getAttendanceRecords().get("Mathematics").get("Wednesday 1600 - Lesson 2"));
     }
 
     @Test
     public void toModelType_invalidAttendanceSubjectKey_throwsIllegalValueException() {
         Map<String, Map<String, String>> invalidRecords = new LinkedHashMap<>();
         Map<String, String> lessons = new LinkedHashMap<>();
-        lessons.put("Monday 1400", "Present");
+        lessons.put("Monday 1400 - Lesson 1", "Present");
         invalidRecords.put("!InvalidSubject", lessons);
 
         JsonAdaptedPerson person = new JsonAdaptedPerson(
@@ -349,8 +349,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void constructor_attendanceWithNullSubjectKey_skipsSilently() throws Exception {
         Map<String, Map<String, AttendanceStatus>> records = new LinkedHashMap<>();
-        records.put(null, Map.of("Monday 1400", AttendanceStatus.PRESENT));
-        records.put("Math", Map.of("Monday 1400", AttendanceStatus.PRESENT));
+        records.put(null, Map.of("Monday 1400 - Lesson 1", AttendanceStatus.PRESENT));
+        records.put("Math", Map.of("Monday 1400 - Lesson 1", AttendanceStatus.PRESENT));
 
         Person person = new seedu.address.testutil.PersonBuilder()
                 .withName("Test")
@@ -376,7 +376,7 @@ public class JsonAdaptedPersonTest {
         Map<String, Map<String, AttendanceStatus>> records = new LinkedHashMap<>();
         Map<String, AttendanceStatus> innerMap = new LinkedHashMap<>();
         innerMap.put(null, AttendanceStatus.PRESENT);
-        innerMap.put("Monday 1400", AttendanceStatus.ABSENT);
+        innerMap.put("Monday 1400 - Lesson 1", AttendanceStatus.ABSENT);
         records.put("Math", innerMap);
 
         Person person = new seedu.address.testutil.PersonBuilder()
@@ -397,15 +397,15 @@ public class JsonAdaptedPersonTest {
         Map<String, Map<String, AttendanceStatus>> restoredRecords =
                 restored.getAttendanceRecords();
         assertEquals(1, restoredRecords.get("Math").size());
-        assertTrue(restoredRecords.get("Math").containsKey("Monday 1400"));
+        assertTrue(restoredRecords.get("Math").containsKey("Monday 1400 - Lesson 1"));
     }
 
     @Test
     public void constructor_attendanceWithNullStatus_skipsSilently() throws Exception {
         Map<String, Map<String, AttendanceStatus>> records = new LinkedHashMap<>();
         Map<String, AttendanceStatus> innerMap = new LinkedHashMap<>();
-        innerMap.put("Monday 1400", null);
-        innerMap.put("Tuesday 1600", AttendanceStatus.PRESENT);
+        innerMap.put("Monday 1400 - Lesson 1", null);
+        innerMap.put("Tuesday 1600 - Lesson 2", AttendanceStatus.PRESENT);
         records.put("Math", innerMap);
 
         Person person = new seedu.address.testutil.PersonBuilder()
@@ -426,6 +426,6 @@ public class JsonAdaptedPersonTest {
         Map<String, Map<String, AttendanceStatus>> restoredRecords =
                 restored.getAttendanceRecords();
         assertEquals(1, restoredRecords.get("Math").size());
-        assertTrue(restoredRecords.get("Math").containsKey("Tuesday 1600"));
+        assertTrue(restoredRecords.get("Math").containsKey("Tuesday 1600 - Lesson 2"));
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAttendanceStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAttendanceStorageTest.java
@@ -34,8 +34,8 @@ public class JsonAttendanceStorageTest {
     @Test
     public void saveAndRead_personWithAttendance_roundTrip() throws Exception {
         Person personWithAttendance = ALICE
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT)
-                .markAttendance("Mathematics", "Wednesday 1600", AttendanceStatus.ABSENT);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT)
+                .markAttendance("Mathematics", "Wednesday 1600 - Lesson 2", AttendanceStatus.ABSENT);
 
         AddressBook original = new AddressBook();
         original.addPerson(personWithAttendance);
@@ -49,17 +49,17 @@ public class JsonAttendanceStorageTest {
 
         Person restored = readBack.getPersonList().get(0);
         assertEquals(AttendanceStatus.PRESENT,
-                restored.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                restored.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
         assertEquals(AttendanceStatus.ABSENT,
-                restored.getAttendanceRecords().get("Mathematics").get("Wednesday 1600"));
+                restored.getAttendanceRecords().get("Mathematics").get("Wednesday 1600 - Lesson 2"));
     }
 
     @Test
     public void saveAndRead_multipleSubjectsAndLessons_allPreserved() throws Exception {
         Person person = ALICE
-                .markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT)
-                .markAttendance("Mathematics", "Wednesday 1600", AttendanceStatus.ABSENT)
-                .markAttendance("English", "Tuesday 0900", AttendanceStatus.EXCUSED);
+                .markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT)
+                .markAttendance("Mathematics", "Wednesday 1600 - Lesson 2", AttendanceStatus.ABSENT)
+                .markAttendance("English", "Tuesday 0900 - Lesson 3", AttendanceStatus.EXCUSED);
 
         AddressBook original = new AddressBook();
         original.addPerson(person);
@@ -75,7 +75,7 @@ public class JsonAttendanceStorageTest {
         assertEquals(2, restored.getAttendanceRecords().get("Mathematics").size());
         assertEquals(1, restored.getAttendanceRecords().get("English").size());
         assertEquals(AttendanceStatus.EXCUSED,
-                restored.getAttendanceRecords().get("English").get("Tuesday 0900"));
+                restored.getAttendanceRecords().get("English").get("Tuesday 0900 - Lesson 3"));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class JsonAttendanceStorageTest {
 
     @Test
     public void saveAndRead_overwriteAttendance_updatesCorrectly() throws Exception {
-        Person original = ALICE.markAttendance("Mathematics", "Monday 1400", AttendanceStatus.ABSENT);
+        Person original = ALICE.markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.ABSENT);
         AddressBook ab = new AddressBook();
         ab.addPerson(original);
 
@@ -103,14 +103,14 @@ public class JsonAttendanceStorageTest {
         storage.saveAddressBook(ab, filePath);
 
         // Update attendance and save again
-        Person updated = original.markAttendance("Mathematics", "Monday 1400", AttendanceStatus.PRESENT);
+        Person updated = original.markAttendance("Mathematics", "Monday 1400 - Lesson 1", AttendanceStatus.PRESENT);
         ab.setPerson(original, updated);
         storage.saveAddressBook(ab, filePath);
 
         ReadOnlyAddressBook readBack = storage.readAddressBook(filePath).get();
         Person restored = readBack.getPersonList().get(0);
         assertEquals(AttendanceStatus.PRESENT,
-                restored.getAttendanceRecords().get("Mathematics").get("Monday 1400"));
+                restored.getAttendanceRecords().get("Mathematics").get("Monday 1400 - Lesson 1"));
     }
 
     // ==================== Backward compatibility ====================


### PR DESCRIPTION
## Summary
- Add `AttendanceRecordKey` utility class with `of()`, `getLessonSlotKey()`, and `isValid()` to support the new `"Day Time - Lesson"` attendance key format
- Update `Lesson` regex to allow hyphens for date-based labels (e.g., `2026-04-13 Algebra Lesson 2`)
- Add `parseLessonName` to `ParserUtil` for validating lesson/session labels
- Switch `JsonAdaptedPerson` from `isValidAttendanceKey` to `AttendanceRecordKey.isValid()`
- Fix `EditCommand.pruneAttendanceRecords` to extract slot keys from full record keys using `AttendanceRecordKey.getLessonSlotKey()`

## Context
This is the infrastructure portion of the attendance lesson-key change (issue #251). Dayne's command-facing changes (`MarkAttendanceCommandParser`, `MarkAttendanceCommand`, `CliSyntax`) depend on this PR landing first.

Fixes #251

## Test plan
- [x] `AttendanceRecordKeyTest` — validates `of()`, `getLessonSlotKey()`, `isValid()` with valid/invalid inputs
- [x] Updated `PersonAttendanceTest` — all attendance keys use new `"Day Time - Lesson"` format
- [x] Updated `JsonAdaptedPersonTest` — round-trip tests, null-guard tests, validation tests all use new key format
- [x] Updated `JsonAttendanceStorageTest` — persistence round-trip tests use new key format
- [x] Updated `EditCommandTest` — pruning tests verify correct behavior with new key format
- [x] `./gradlew checkstyleMain checkstyleTest` passes
- [x] `./gradlew test` — 588 tests, 0 failures