### PR TITLE
Fix: l/LESSON parameter for markattendance command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1114,5 +1114,3 @@ Team size: 5
 13. **Allow remarks to be added during student creation.** Currently, remarks can only be added after a student has been created using the separate `remark` command. We will support an optional `r/REMARK` field in the `add` command so tutors can record initial notes while creating a student, while keeping the existing `remark` command for later updates.
 
 14. **Add lesson end times to lesson slots.** Currently each lesson slot only records a start time (e.g., `ti/1400`). We plan to add an optional end time parameter (e.g., `te/1530`) to `LessonSlot` so tutors can see the full duration of each lesson.
-
-15. **Validate `l/LESSON` as a structured date.** Currently `markattendance` uses a free-text `l/LESSON` session label. Tutors can include dates manually (e.g., `l/2026-04-13 Algebra Lesson 2`), but TutorCentral does not validate, sort, or filter attendance records by date. We plan to add a dedicated `date/DATE` parameter so attendance records can be stored and queried using actual lesson dates, enabling chronological sorting and date-range filtering.

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -13,6 +14,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.AttendanceRecordKey;
 import seedu.address.model.person.AttendanceStatus;
 import seedu.address.model.person.Person;
 
@@ -30,23 +32,26 @@ public class MarkAttendanceCommand extends Command {
             + PREFIX_SUBJECT + "SUBJECT "
             + PREFIX_DAY + "DAY "
             + PREFIX_TIME + "TIME "
+            + PREFIX_LESSON + "LESSON "
             + PREFIX_ATTENDANCE_STATUS + "STATUS\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_SUBJECT + "Mathematics "
             + PREFIX_DAY + "Monday "
             + PREFIX_TIME + "1400 "
+            + PREFIX_LESSON + "2026-04-13 Algebra Lesson 2 "
             + PREFIX_ATTENDANCE_STATUS + "Present\n"
             + "Example: " + COMMAND_WORD + " 1,2,3 "
             + PREFIX_SUBJECT + "Mathematics "
             + PREFIX_DAY + "Monday "
             + PREFIX_TIME + "1400 "
+            + PREFIX_LESSON + "Week 1 "
             + PREFIX_ATTENDANCE_STATUS + "Present";
 
     public static final String MESSAGE_MARK_ATTENDANCE_SUCCESS =
-            "Marked attendance for %1$s: %2$s - %3$s %4$s as %5$s";
+            "Marked attendance for %1$s: %2$s - %3$s %4$s (%5$s) as %6$s";
 
     public static final String MESSAGE_MARK_ATTENDANCE_MULTIPLE_SUCCESS =
-            "Marked attendance for %1$d students in %2$s - %3$s %4$s as %5$s";
+            "Marked attendance for %1$d students in %2$s - %3$s %4$s (%5$s) as %6$s";
 
     public static final String MESSAGE_SUBJECT_NOT_FOUND =
             "The student does not take the subject: %1$s";
@@ -55,6 +60,7 @@ public class MarkAttendanceCommand extends Command {
     private final String subject;
     private final String day;
     private final String time;
+    private final String lesson;
     private final AttendanceStatus status;
 
     /**
@@ -62,20 +68,23 @@ public class MarkAttendanceCommand extends Command {
      * @param subject     the subject name to mark attendance for
      * @param day         the day of the lesson
      * @param time        the time of the lesson
+     * @param lesson      the lesson label to distinguish different sessions
      * @param status      the attendance status to record
      */
     public MarkAttendanceCommand(Index[] targetIndices, String subject,
-            String day, String time, AttendanceStatus status) {
+            String day, String time, String lesson, AttendanceStatus status) {
         requireNonNull(targetIndices);
         requireNonNull(subject);
         requireNonNull(day);
         requireNonNull(time);
+        requireNonNull(lesson);
         requireNonNull(status);
 
         this.targetIndices = targetIndices;
         this.subject = subject;
         this.day = day;
         this.time = time;
+        this.lesson = lesson;
         this.status = status;
     }
 
@@ -83,8 +92,8 @@ public class MarkAttendanceCommand extends Command {
      * Convenience constructor for single student (backward compatibility)
      */
     public MarkAttendanceCommand(Index targetIndex, String subject,
-            String day, String time, AttendanceStatus status) {
-        this(new Index[]{targetIndex}, subject, day, time, status);
+            String day, String time, String lesson, AttendanceStatus status) {
+        this(new Index[]{targetIndex}, subject, day, time, lesson, status);
     }
 
     @Override
@@ -119,6 +128,7 @@ public class MarkAttendanceCommand extends Command {
                             String.format(MESSAGE_SUBJECT_NOT_FOUND, subject)));
 
             String dayTime = day + " " + time;
+            String attendanceKey = AttendanceRecordKey.of(day, time, lesson);
 
             if (!personToMark.hasLessonSlot(matchedSubject, dayTime)) {
                 throw new CommandException(
@@ -126,7 +136,7 @@ public class MarkAttendanceCommand extends Command {
                                 matchedSubject, day, time));
             }
 
-            Person markedPerson = personToMark.markAttendance(matchedSubject, dayTime, status);
+            Person markedPerson = personToMark.markAttendance(matchedSubject, attendanceKey, status);
             model.setPerson(personToMark, markedPerson);
         }
 
@@ -135,9 +145,9 @@ public class MarkAttendanceCommand extends Command {
         // Return appropriate success message
         String successMessage = targetIndices.length == 1
                 ? String.format(MESSAGE_MARK_ATTENDANCE_SUCCESS,
-                        personsToMark[0].getName(), subject, day, time, status.value)
+                        personsToMark[0].getName(), subject, day, time, lesson, status.value)
                 : String.format(MESSAGE_MARK_ATTENDANCE_MULTIPLE_SUCCESS,
-                        targetIndices.length, subject, day, time, status.value);
+                        targetIndices.length, subject, day, time, lesson, status.value);
 
         return new CommandResult(successMessage);
     }
@@ -154,6 +164,7 @@ public class MarkAttendanceCommand extends Command {
                 && subject.equals(otherCmd.subject)
                 && day.equals(otherCmd.day)
                 && time.equals(otherCmd.time)
+                && lesson.equals(otherCmd.lesson)
                 && status.equals(otherCmd.status);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DAY = new Prefix("d/");
     public static final Prefix PREFIX_TIME = new Prefix("ti/");
+    public static final Prefix PREFIX_LESSON = new Prefix("l/");
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_ATTENDANCE_STATUS = new Prefix("st/");
 

--- a/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
@@ -28,15 +29,16 @@ public class MarkAttendanceCommandParser implements Parser<MarkAttendanceCommand
         requireNonNull(args);
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
-                args, PREFIX_SUBJECT, PREFIX_DAY, PREFIX_TIME, PREFIX_ATTENDANCE_STATUS);
+                args, PREFIX_SUBJECT, PREFIX_DAY, PREFIX_TIME, PREFIX_LESSON, PREFIX_ATTENDANCE_STATUS);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_SUBJECT, PREFIX_DAY, PREFIX_TIME, PREFIX_ATTENDANCE_STATUS)
-                || argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_SUBJECT, PREFIX_DAY, PREFIX_TIME, PREFIX_LESSON,
+                PREFIX_ATTENDANCE_STATUS) || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SUBJECT, PREFIX_DAY, PREFIX_TIME, PREFIX_ATTENDANCE_STATUS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SUBJECT, PREFIX_DAY, PREFIX_TIME, PREFIX_LESSON,
+                PREFIX_ATTENDANCE_STATUS);
 
         Index[] indices;
         try {
@@ -60,10 +62,11 @@ public class MarkAttendanceCommandParser implements Parser<MarkAttendanceCommand
         String subject = ParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT).get()).subjectName;
         String day = ParserUtil.parseDay(argMultimap.getValue(PREFIX_DAY).get()).dayName;
         String time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get()).timeValue;
+        String lesson = argMultimap.getValue(PREFIX_LESSON).get().trim();
         AttendanceStatus status = ParserUtil.parseAttendanceStatus(
                 argMultimap.getValue(PREFIX_ATTENDANCE_STATUS).get());
 
-        return new MarkAttendanceCommand(indices, subject, day, time, status);
+        return new MarkAttendanceCommand(indices, subject, day, time, lesson, status);
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/test/java/seedu/address/logic/LessonSlotIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/LessonSlotIntegrationTest.java
@@ -166,7 +166,7 @@ public class LessonSlotIntegrationTest {
     public void execute_editLessonSlots_removesStaleAttendanceRecords() throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Present");
+                + "ti/1400 l/Week 1 st/Present");
         logic.execute("edit 1 s/English d/Friday ti/1000");
 
         Person edited = logic.getFilteredPersonList().get(0);
@@ -188,33 +188,33 @@ public class LessonSlotIntegrationTest {
     public void execute_markAttendancePresent_success() throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Present");
+                + "ti/1400 l/Week 1 st/Present");
         Person alice = logic.getFilteredPersonList().get(0);
         assertEquals(AttendanceStatus.PRESENT,
                 alice.getAttendanceRecords()
-                        .get("Mathematics").get("Monday 1400"));
+                        .get("Mathematics").get("Monday 1400 - Week 1"));
     }
 
     @Test
     public void execute_markAttendanceAbsent_success() throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Absent");
+                + "ti/1400 l/Week 1 st/Absent");
         Person alice = logic.getFilteredPersonList().get(0);
         assertEquals(AttendanceStatus.ABSENT,
                 alice.getAttendanceRecords()
-                        .get("Mathematics").get("Monday 1400"));
+                        .get("Mathematics").get("Monday 1400 - Week 1"));
     }
 
     @Test
     public void execute_markAttendanceExcused_success() throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Excused");
+                + "ti/1400 l/Week 1 st/Excused");
         Person alice = logic.getFilteredPersonList().get(0);
         assertEquals(AttendanceStatus.EXCUSED,
                 alice.getAttendanceRecords()
-                        .get("Mathematics").get("Monday 1400"));
+                        .get("Mathematics").get("Monday 1400 - Week 1"));
     }
 
     @Test
@@ -222,11 +222,11 @@ public class LessonSlotIntegrationTest {
             throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/present");
+                + "ti/1400 l/Week 1 st/present");
         Person alice = logic.getFilteredPersonList().get(0);
         assertEquals(AttendanceStatus.PRESENT,
                 alice.getAttendanceRecords()
-                        .get("Mathematics").get("Monday 1400"));
+                        .get("Mathematics").get("Monday 1400 - Week 1"));
     }
 
     @Test
@@ -234,21 +234,21 @@ public class LessonSlotIntegrationTest {
             throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Present");
+                + "ti/1400 l/Week 1 st/Present");
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Absent");
+                + "ti/1400 l/Week 1 st/Absent");
         Person alice = logic.getFilteredPersonList().get(0);
         assertEquals(AttendanceStatus.ABSENT,
                 alice.getAttendanceRecords()
-                        .get("Mathematics").get("Monday 1400"));
+                        .get("Mathematics").get("Monday 1400 - Week 1"));
     }
 
     @Test
     public void execute_markAttendanceInvalidStatus_fails() {
         assertThrowsParseOrCommand(() -> logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Maybe"));
+                + "ti/1400 l/Week 1 st/Maybe"));
         Person alice = logic.getFilteredPersonList().get(0);
         assertTrue(alice.getAttendanceRecords().isEmpty());
     }
@@ -257,7 +257,7 @@ public class LessonSlotIntegrationTest {
     public void execute_markAttendanceInvalidDay_fails() {
         assertThrowsParseOrCommand(() -> logic.execute(
                 "markattendance 1 s/Mathematics d/Funday "
-                + "ti/1400 st/Present"));
+                + "ti/1400 l/Week 1 st/Present"));
         Person alice = logic.getFilteredPersonList().get(0);
         assertTrue(alice.getAttendanceRecords().isEmpty());
     }
@@ -266,7 +266,7 @@ public class LessonSlotIntegrationTest {
     public void execute_markAttendanceInvalidTime_fails() {
         assertThrowsParseOrCommand(() -> logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/9999 st/Present"));
+                + "ti/9999 l/Week 1 st/Present"));
         Person alice = logic.getFilteredPersonList().get(0);
         assertTrue(alice.getAttendanceRecords().isEmpty());
     }
@@ -295,7 +295,7 @@ public class LessonSlotIntegrationTest {
             throws Exception {
         logic.execute(
                 "markattendance 1 s/Mathematics d/Monday "
-                + "ti/1400 st/Present");
+                + "ti/1400 l/Week 1 st/Present");
         CommandResult result = logic.execute("listattendance 1");
         String feedback = result.getFeedbackToUser();
         assertTrue(feedback.contains("Mathematics")
@@ -445,11 +445,11 @@ public class LessonSlotIntegrationTest {
 
         // Mark attendance
         logic.execute("markattendance " + displayIdx
-                + " s/Physics d/Thursday ti/1600 st/Present");
+                + " s/Physics d/Thursday ti/1600 l/Week 1 st/Present");
         student = logic.getFilteredPersonList().get(idx);
         assertEquals(AttendanceStatus.PRESENT,
                 student.getAttendanceRecords()
-                        .get("Physics").get("Thursday 1600"));
+                        .get("Physics").get("Thursday 1600 - Week 1"));
 
         // List attendance
         CommandResult listResult = logic.execute(

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -31,6 +31,7 @@ public class MarkAttendanceCommandTest {
     private static final String VALID_SUBJECT = "Mathematics";
     private static final String VALID_DAY = "Monday";
     private static final String VALID_TIME = "1400";
+    private static final String VALID_LESSON = "Week 1";
     private static final AttendanceStatus STATUS_PRESENT = AttendanceStatus.PRESENT;
     private static final AttendanceStatus STATUS_ABSENT = AttendanceStatus.ABSENT;
 
@@ -39,13 +40,14 @@ public class MarkAttendanceCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person markedPerson = personToMark.markAttendance(VALID_SUBJECT, VALID_DAY + " " + VALID_TIME, STATUS_PRESENT);
+        Person markedPerson = personToMark.markAttendance(VALID_SUBJECT,
+                VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_PRESENT);
 
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         String expectedMessage = String.format(MarkAttendanceCommand.MESSAGE_MARK_ATTENDANCE_SUCCESS,
-                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT.value);
+                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT.value);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToMark, markedPerson);
@@ -59,13 +61,13 @@ public class MarkAttendanceCommandTest {
 
         Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person markedPerson = personToMark.markAttendance(VALID_SUBJECT,
-                VALID_DAY + " " + VALID_TIME, STATUS_ABSENT);
+                VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_ABSENT);
 
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_ABSENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_ABSENT);
 
         String expectedMessage = String.format(MarkAttendanceCommand.MESSAGE_MARK_ATTENDANCE_SUCCESS,
-                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_ABSENT.value);
+                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_ABSENT.value);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToMark, markedPerson);
@@ -77,7 +79,7 @@ public class MarkAttendanceCommandTest {
     public void execute_invalidIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                outOfBoundIndex, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                outOfBoundIndex, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         assertCommandFailure(command, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -89,7 +91,7 @@ public class MarkAttendanceCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                outOfBoundIndex, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                outOfBoundIndex, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         assertCommandFailure(command, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -97,7 +99,7 @@ public class MarkAttendanceCommandTest {
     @Test
     public void execute_subjectNotFound_failure() {
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, "Physics", VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                INDEX_FIRST_PERSON, "Physics", VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         assertCommandFailure(command, model,
                 String.format(MarkAttendanceCommand.MESSAGE_SUBJECT_NOT_FOUND, "Physics"));
@@ -107,7 +109,7 @@ public class MarkAttendanceCommandTest {
     public void execute_lessonSlotNotFound_failure() {
         // ALICE has Mathematics on Monday 1400, not Tuesday 0900
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, "Tuesday", "0900", STATUS_PRESENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, "Tuesday", "0900", VALID_LESSON, STATUS_PRESENT);
 
         assertCommandFailure(command, model,
                 String.format(Messages.MESSAGE_LESSON_SLOT_NOT_FOUND, VALID_SUBJECT, "Tuesday", "0900"));
@@ -117,13 +119,13 @@ public class MarkAttendanceCommandTest {
     public void execute_subjectMatchCaseInsensitive_success() {
         Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person markedPerson = personToMark.markAttendance(VALID_SUBJECT,
-                VALID_DAY + " " + VALID_TIME, STATUS_PRESENT);
+                VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_PRESENT);
 
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         String expectedMessage = String.format(MarkAttendanceCommand.MESSAGE_MARK_ATTENDANCE_SUCCESS,
-                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT.value);
+                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT.value);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToMark, markedPerson);
@@ -137,15 +139,15 @@ public class MarkAttendanceCommandTest {
         // but using same person to avoid subject mismatch issues
         Index[] indices = new Index[]{INDEX_FIRST_PERSON};
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                indices, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                indices, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person markedPerson = personToMark.markAttendance(VALID_SUBJECT,
-                VALID_DAY + " " + VALID_TIME, STATUS_PRESENT);
+                VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_PRESENT);
 
         // Since we're using single index, it should use single success message
         String expectedMessage = String.format(MarkAttendanceCommand.MESSAGE_MARK_ATTENDANCE_SUCCESS,
-                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT.value);
+                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT.value);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToMark, markedPerson);
@@ -159,15 +161,15 @@ public class MarkAttendanceCommandTest {
         // This tests the lines that check array length and determine success message
         Index[] singleIndexArray = new Index[]{INDEX_FIRST_PERSON};
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                singleIndexArray, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                singleIndexArray, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person markedPerson = personToMark.markAttendance(VALID_SUBJECT,
-                VALID_DAY + " " + VALID_TIME, STATUS_PRESENT);
+                VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_PRESENT);
 
         // Since array length is 1, it should use single success message (covers line 136-142 logic)
         String expectedMessage = String.format(MarkAttendanceCommand.MESSAGE_MARK_ATTENDANCE_SUCCESS,
-                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT.value);
+                personToMark.getName(), VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT.value);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToMark, markedPerson);
@@ -192,12 +194,12 @@ public class MarkAttendanceCommandTest {
         Index[] indices = new Index[]{INDEX_FIRST_PERSON,
                 Index.fromOneBased(testModel.getFilteredPersonList().size())};
         MarkAttendanceCommand command = new MarkAttendanceCommand(
-                indices, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                indices, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         // This should trigger the multiple success message since indices.length > 1
         String expectedMessage = String.format(
                 MarkAttendanceCommand.MESSAGE_MARK_ATTENDANCE_MULTIPLE_SUCCESS,
-                2, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT.value);
+                2, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT.value);
 
         // Create expected model with both persons marked
         Model expectedModel = new ModelManager(new AddressBook(testModel.getAddressBook()), new UserPrefs());
@@ -206,9 +208,9 @@ public class MarkAttendanceCommandTest {
                 .get(Index.fromOneBased(expectedModel.getFilteredPersonList().size()).getZeroBased());
 
         Person markedFirstPerson = firstPerson.markAttendance(
-                VALID_SUBJECT, VALID_DAY + " " + VALID_TIME, STATUS_PRESENT);
+                VALID_SUBJECT, VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_PRESENT);
         Person markedSecondPerson = secondPerson.markAttendance(
-                VALID_SUBJECT, VALID_DAY + " " + VALID_TIME, STATUS_PRESENT);
+                VALID_SUBJECT, VALID_DAY + " " + VALID_TIME + " - " + VALID_LESSON, STATUS_PRESENT);
 
         expectedModel.setPerson(firstPerson, markedFirstPerson);
         expectedModel.setPerson(secondPerson, markedSecondPerson);
@@ -220,16 +222,16 @@ public class MarkAttendanceCommandTest {
     @Test
     public void equals() {
         MarkAttendanceCommand commandA = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
         MarkAttendanceCommand commandB = new MarkAttendanceCommand(
-                INDEX_SECOND_PERSON, "English", "Tuesday", "0900", STATUS_ABSENT);
+                INDEX_SECOND_PERSON, "English", "Tuesday", "0900", VALID_LESSON, STATUS_ABSENT);
 
         // same object
         assertTrue(commandA.equals(commandA));
 
         // same values
         assertTrue(commandA.equals(new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT)));
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT)));
 
         // different types
         assertFalse(commandA.equals(1));
@@ -239,23 +241,23 @@ public class MarkAttendanceCommandTest {
 
         // different index
         assertFalse(commandA.equals(new MarkAttendanceCommand(
-                INDEX_SECOND_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT)));
+                INDEX_SECOND_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT)));
 
         // different subject
         assertFalse(commandA.equals(new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, "English", VALID_DAY, VALID_TIME, STATUS_PRESENT)));
+                INDEX_FIRST_PERSON, "English", VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT)));
 
         // different day
         assertFalse(commandA.equals(new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, "Tuesday", VALID_TIME, STATUS_PRESENT)));
+                INDEX_FIRST_PERSON, VALID_SUBJECT, "Tuesday", VALID_TIME, VALID_LESSON, STATUS_PRESENT)));
 
         // different time
         assertFalse(commandA.equals(new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, "0900", STATUS_PRESENT)));
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, "0900", VALID_LESSON, STATUS_PRESENT)));
 
         // different status
         assertFalse(commandA.equals(new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_ABSENT)));
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_ABSENT)));
 
         // entirely different command
         assertFalse(commandA.equals(commandB));
@@ -266,11 +268,11 @@ public class MarkAttendanceCommandTest {
         Index[] indices3 = new Index[]{INDEX_SECOND_PERSON, INDEX_FIRST_PERSON};
 
         MarkAttendanceCommand multiCommandA = new MarkAttendanceCommand(
-                indices1, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                indices1, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
         MarkAttendanceCommand multiCommandB = new MarkAttendanceCommand(
-                indices2, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                indices2, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
         MarkAttendanceCommand multiCommandC = new MarkAttendanceCommand(
-                indices3, VALID_SUBJECT, VALID_DAY, VALID_TIME, STATUS_PRESENT);
+                indices3, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, STATUS_PRESENT);
 
         // same multiple indices
         assertTrue(multiCommandA.equals(multiCommandB));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -175,9 +175,9 @@ public class AddressBookParserTest {
     public void parseCommand_markAttendance() throws Exception {
         MarkAttendanceCommand command = (MarkAttendanceCommand) parser.parseCommand(
                         MarkAttendanceCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
-                                        + " s/Mathematics d/Monday ti/1400 st/Present");
+                                        + " s/Mathematics d/Monday ti/1400 l/Week 1 st/Present");
         assertEquals(new MarkAttendanceCommand(
-                        INDEX_FIRST_PERSON, "Mathematics", "Monday", "1400",
+                        INDEX_FIRST_PERSON, "Mathematics", "Monday", "1400", "Week 1",
                         AttendanceStatus.PRESENT), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/MarkAttendanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkAttendanceCommandParserTest.java
@@ -195,6 +195,19 @@ public class MarkAttendanceCommandParserTest {
     }
 
     @Test
+    public void parse_missingIndexWithAllPrefixes_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                MarkAttendanceCommand.MESSAGE_USAGE);
+        assertParseFailure(parser,
+                " " + PREFIX_SUBJECT + VALID_SUBJECT + " "
+                        + PREFIX_DAY + VALID_DAY + " "
+                        + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
+                        + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
+                expectedMessage);
+    }
+
+    @Test
     public void parse_duplicatePrefixes_failure() {
         assertParseFailure(parser,
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " " + PREFIX_SUBJECT + "English "

--- a/src/test/java/seedu/address/logic/parser/MarkAttendanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkAttendanceCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -25,6 +26,7 @@ public class MarkAttendanceCommandParserTest {
     private static final String VALID_SUBJECT = "Mathematics";
     private static final String VALID_DAY = "Monday";
     private static final String VALID_TIME = "1400";
+    private static final String VALID_LESSON = "Week 1";
     private static final String VALID_STATUS = "Present";
 
     private MarkAttendanceCommandParser parser = new MarkAttendanceCommandParser();
@@ -32,12 +34,13 @@ public class MarkAttendanceCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         MarkAttendanceCommand expected = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, AttendanceStatus.PRESENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, AttendanceStatus.PRESENT);
 
         assertParseSuccess(parser,
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expected);
     }
@@ -45,12 +48,13 @@ public class MarkAttendanceCommandParserTest {
     @Test
     public void parse_caseInsensitiveStatus_success() {
         MarkAttendanceCommand expected = new MarkAttendanceCommand(
-                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, AttendanceStatus.PRESENT);
+                INDEX_FIRST_PERSON, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, AttendanceStatus.PRESENT);
 
         assertParseSuccess(parser,
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + "present",
                 expected);
 
@@ -58,6 +62,7 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + "PRESENT",
                 expected);
     }
@@ -124,6 +129,7 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + "Invalid",
                 AttendanceStatus.MESSAGE_CONSTRAINTS);
     }
@@ -134,6 +140,7 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + "!!invalid "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 Subject.MESSAGE_CONSTRAINTS);
     }
@@ -144,6 +151,7 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + "Mon@day "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 Day.MESSAGE_CONSTRAINTS);
     }
@@ -154,6 +162,7 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + "14pm "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 Time.MESSAGE_CONSTRAINTS);
     }
@@ -166,12 +175,14 @@ public class MarkAttendanceCommandParserTest {
                 "0 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expectedMessage);
         assertParseFailure(parser,
                 "-1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expectedMessage);
     }
@@ -189,6 +200,7 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " " + PREFIX_SUBJECT + "English "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
 
@@ -196,13 +208,31 @@ public class MarkAttendanceCommandParserTest {
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " " + PREFIX_DAY + "Tuesday "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DAY));
 
         assertParseFailure(parser,
                 "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
+                        + PREFIX_TIME + VALID_TIME + " " + PREFIX_TIME + "1500 "
+                        + PREFIX_LESSON + VALID_LESSON + " "
+                        + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TIME));
+
+        assertParseFailure(parser,
+                "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
+                        + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " " + PREFIX_LESSON + "Week 2 "
+                        + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LESSON));
+
+        assertParseFailure(parser,
+                "1 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
+                        + PREFIX_DAY + VALID_DAY + " "
+                        + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS + " "
                         + PREFIX_ATTENDANCE_STATUS + "Absent",
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ATTENDANCE_STATUS));
@@ -212,12 +242,13 @@ public class MarkAttendanceCommandParserTest {
     public void parse_multipleIndices_success() {
         Index[] expectedIndices = new Index[]{INDEX_FIRST_PERSON, INDEX_SECOND_PERSON};
         MarkAttendanceCommand expected = new MarkAttendanceCommand(
-                expectedIndices, VALID_SUBJECT, VALID_DAY, VALID_TIME, AttendanceStatus.PRESENT);
+                expectedIndices, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, AttendanceStatus.PRESENT);
 
         assertParseSuccess(parser,
                 "1,2 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expected);
     }
@@ -226,12 +257,13 @@ public class MarkAttendanceCommandParserTest {
     public void parse_multipleIndicesWithSpaces_success() {
         Index[] expectedIndices = new Index[]{INDEX_FIRST_PERSON, INDEX_SECOND_PERSON};
         MarkAttendanceCommand expected = new MarkAttendanceCommand(
-                expectedIndices, VALID_SUBJECT, VALID_DAY, VALID_TIME, AttendanceStatus.PRESENT);
+                expectedIndices, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, AttendanceStatus.PRESENT);
 
         assertParseSuccess(parser,
                 "1, 2 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expected);
     }
@@ -241,12 +273,13 @@ public class MarkAttendanceCommandParserTest {
         Index[] expectedIndices = new Index[]{
             INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, Index.fromOneBased(3)};
         MarkAttendanceCommand expected = new MarkAttendanceCommand(
-                expectedIndices, VALID_SUBJECT, VALID_DAY, VALID_TIME, AttendanceStatus.PRESENT);
+                expectedIndices, VALID_SUBJECT, VALID_DAY, VALID_TIME, VALID_LESSON, AttendanceStatus.PRESENT);
 
         assertParseSuccess(parser,
                 "1,2,3 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expected);
     }
@@ -259,6 +292,7 @@ public class MarkAttendanceCommandParserTest {
                 "1,0 " + PREFIX_SUBJECT + VALID_SUBJECT + " "
                         + PREFIX_DAY + VALID_DAY + " "
                         + PREFIX_TIME + VALID_TIME + " "
+                        + PREFIX_LESSON + VALID_LESSON + " "
                         + PREFIX_ATTENDANCE_STATUS + VALID_STATUS,
                 expectedMessage);
     }


### PR DESCRIPTION
- Add PREFIX_LESSON to CliSyntax.java
- Update MarkAttendanceCommandParser to parse l/ parameter
- Update MarkAttendanceCommand to use lesson label in attendance key
- Update success messages to include lesson
- Update equals method to compare lesson field
- Fix all test files to use new constructor signature
- Fix checkstyle line length violations
- Update integration tests to include l/LESSON parameter

This allows distinguishing attendance for different lesson sessions (e.g., Week 1 vs Week 2) for the same day and time slot.
fixes #311 